### PR TITLE
feat(tensor): add uniform/normal random tensor initializers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/sahandsafizadeh/qeep
 
 go 1.22
+
+require gonum.org/v1/gonum v0.15.0
+
+require golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa h1:FRnLl4eNAQl8hwxVVC17teOw8kdjVDVAiFMtgUdTSRQ=
+golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa/go.mod h1:zk2irFbV9DP96SEBUUAy67IdHUaZuSnrz1n472HUCLE=
+gonum.org/v1/gonum v0.15.0 h1:2lYxjRbTYyxkJxlhC+LvJIx3SsANPdRybu1tGj9/OrQ=
+gonum.org/v1/gonum v0.15.0/go.mod h1:xzZVBJBtS+Mz4q0Yl2LJTk+OxOg4jiXZ7qBoM0uISGo=

--- a/tensor/internal/cputensor/cputensor.go
+++ b/tensor/internal/cputensor/cputensor.go
@@ -50,6 +50,50 @@ func Eye(n int32, withGrad bool) (o tensor.Tensor, err error) {
 	return r, nil
 }
 
+func RandU(l, u float64, dims []int32, withGrad bool) (o tensor.Tensor, err error) {
+	err = validator.ValidateRandUParams(l, u)
+	if err != nil {
+		err = fmt.Errorf("random parameter validation failed: %w", err)
+		return
+	}
+
+	err = validator.ValidateInputDims(dims)
+	if err != nil {
+		err = fmt.Errorf("input dimension validation failed: %w", err)
+		return
+	}
+
+	r := uniformRandomTensor(l, u, dims)
+
+	if withGrad {
+		r.gctx = gradtrack.Root()
+	}
+
+	return r, nil
+}
+
+func RandN(u, s float64, dims []int32, withGrad bool) (o tensor.Tensor, err error) {
+	err = validator.ValidateRandNParams(u, s)
+	if err != nil {
+		err = fmt.Errorf("random parameter validation failed: %w", err)
+		return
+	}
+
+	err = validator.ValidateInputDims(dims)
+	if err != nil {
+		err = fmt.Errorf("input dimension validation failed: %w", err)
+		return
+	}
+
+	r := normalRandomTensor(u, s, dims)
+
+	if withGrad {
+		r.gctx = gradtrack.Root()
+	}
+
+	return r, nil
+}
+
 func TensorOf(data any, withGrad bool) (o tensor.Tensor, err error) {
 	err = validator.ValidateInputDataDimUnity(data)
 	if err != nil {

--- a/tensor/internal/cputensor/initializers.go
+++ b/tensor/internal/cputensor/initializers.go
@@ -1,10 +1,6 @@
 package cputensor
 
-import (
-	"math/rand"
-
-	"gonum.org/v1/gonum/stat/distuv"
-)
+import "gonum.org/v1/gonum/stat/distuv"
 
 func (t *CPUTensor) initWith(initFunc initializerFunc) {
 
@@ -49,7 +45,7 @@ func uniformRandomTensor(l, u float64, dims []int32) (t *CPUTensor) {
 	t.dims = make([]int32, len(dims))
 	copy(t.dims, dims)
 	t.initWith(func() any {
-		return l + rand.Float64()*(u-l)
+		return distuv.Uniform{Min: l, Max: u}.Rand()
 	})
 
 	return t

--- a/tensor/internal/cputensor/initializers.go
+++ b/tensor/internal/cputensor/initializers.go
@@ -1,5 +1,11 @@
 package cputensor
 
+import (
+	"math/rand"
+
+	"gonum.org/v1/gonum/stat/distuv"
+)
+
 func (t *CPUTensor) initWith(initFunc initializerFunc) {
 
 	var fill func([]int32, *any)
@@ -34,6 +40,28 @@ func eyeMatrix(n int32) (t *CPUTensor) {
 	t = new(CPUTensor)
 	t.dims = []int32{n, n}
 	t.initWith(eyeElemGenerator(n))
+
+	return t
+}
+
+func uniformRandomTensor(l, u float64, dims []int32) (t *CPUTensor) {
+	t = new(CPUTensor)
+	t.dims = make([]int32, len(dims))
+	copy(t.dims, dims)
+	t.initWith(func() any {
+		return l + rand.Float64()*(u-l)
+	})
+
+	return t
+}
+
+func normalRandomTensor(u, s float64, dims []int32) (t *CPUTensor) {
+	t = new(CPUTensor)
+	t.dims = make([]int32, len(dims))
+	copy(t.dims, dims)
+	t.initWith(func() any {
+		return distuv.Normal{Mu: u, Sigma: s}.Rand()
+	})
 
 	return t
 }

--- a/tensor/internal/validator/initializers.go
+++ b/tensor/internal/validator/initializers.go
@@ -13,6 +13,24 @@ func ValidateInputDims(dims []int32) (err error) {
 	return nil
 }
 
+func ValidateRandUParams(l, u float64) (err error) {
+	if !(l < u) {
+		err = fmt.Errorf("expected uniform random lower bound to be less than the upper bound: (%f) >= (%f)", l, u)
+		return
+	}
+
+	return nil
+}
+
+func ValidateRandNParams(_, s float64) (err error) {
+	if !(s > 0) {
+		err = fmt.Errorf("expected normal random standard deviation to be positive: got (%f)", s)
+		return
+	}
+
+	return nil
+}
+
 func ValidateInputDataDimUnity(data any) (err error) {
 	zeroLenErr := fmt.Errorf("expected data to not have zero length along any dimension")
 	dimUnityErr := fmt.Errorf("expected data to have have equal length along every dimension")

--- a/tensor/tensor_test/forward_test/initializers_accessors_test.go
+++ b/tensor/tensor_test/forward_test/initializers_accessors_test.go
@@ -723,6 +723,50 @@ func TestZerosOnesPatch(t *testing.T) {
 	})
 }
 
+func TestRandoms(t *testing.T) {
+	runTestLogicOnDevices(func(dev tinit.Device) {
+
+		conf := &tinit.Config{Device: dev}
+
+		/* ------------------------------ */
+
+		dims := []int32{3, 4}
+
+		ten, err := tinit.RandU(conf, -1., 1., dims...)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		dims[0] = 1
+		dims[1] = 1
+
+		shape := ten.Shape()
+		if !shapesEqual(shape, []int32{3, 4}) {
+			t.Fatalf("expected tensor to have shape [3, 4], got %v", shape)
+		}
+
+		/* ------------------------------ */
+
+		dims = []int32{3, 4}
+
+		ten, err = tinit.RandN(conf, 0., 1., dims...)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		dims[0] = 1
+		dims[1] = 1
+
+		shape = ten.Shape()
+		if !shapesEqual(shape, []int32{3, 4}) {
+			t.Fatalf("expected tensor to have shape [3, 4], got %v", shape)
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
 func TestConcat(t *testing.T) {
 	runTestLogicOnDevices(func(dev tinit.Device) {
 
@@ -1107,6 +1151,60 @@ func TestValidationFull(t *testing.T) {
 		}
 
 		_, err = tinit.Full(conf, 2., 2, 0, 1)
+		if err == nil {
+			t.Fatalf("expected error because of non-positive dimension")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+func TestValidationRandU(t *testing.T) {
+	runTestLogicOnDevices(func(dev tinit.Device) {
+
+		conf := &tinit.Config{Device: dev}
+
+		/* ------------------------------ */
+
+		_, err := tinit.RandU(conf, 0., -1.)
+		if err == nil {
+			t.Fatalf("expected error because of lower bound not being less than upper bound")
+		}
+
+		_, err = tinit.RandU(conf, 1., 1.)
+		if err == nil {
+			t.Fatalf("expected error because of lower bound not being less than upper bound")
+		}
+
+		_, err = tinit.RandU(conf, -1., 1., -1)
+		if err == nil {
+			t.Fatalf("expected error because of non-positive dimension")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+func TestValidationRandN(t *testing.T) {
+	runTestLogicOnDevices(func(dev tinit.Device) {
+
+		conf := &tinit.Config{Device: dev}
+
+		/* ------------------------------ */
+
+		_, err := tinit.RandN(conf, 0., -1.)
+		if err == nil {
+			t.Fatalf("expected error because of non-positive standard deviation")
+		}
+
+		_, err = tinit.RandN(conf, -1., 0.)
+		if err == nil {
+			t.Fatalf("expected error because of non-positive standard deviation")
+		}
+
+		_, err = tinit.RandN(conf, 0., 1., -1)
 		if err == nil {
 			t.Fatalf("expected error because of non-positive dimension")
 		}

--- a/tensor/tinit/init.go
+++ b/tensor/tinit/init.go
@@ -61,6 +61,34 @@ func Eye(conf *Config, n int32) (t tensor.Tensor, err error) {
 	}
 }
 
+func RandU(conf *Config, l, u float64, dims ...int32) (t tensor.Tensor, err error) {
+	c, err := prepareConfig(conf)
+	if err != nil {
+		return
+	}
+
+	switch c.Device {
+	case CPU:
+		return cputensor.RandU(l, u, dims, c.GradTrack)
+	default:
+		panic("unreachable: unsupported device validated")
+	}
+}
+
+func RandN(conf *Config, u, s float64, dims ...int32) (t tensor.Tensor, err error) {
+	c, err := prepareConfig(conf)
+	if err != nil {
+		return
+	}
+
+	switch c.Device {
+	case CPU:
+		return cputensor.RandN(u, s, dims, c.GradTrack)
+	default:
+		panic("unreachable: unsupported device validated")
+	}
+}
+
 func TensorOf[T inputDataType](conf *Config, data T) (t tensor.Tensor, err error) {
 	c, err := prepareConfig(conf)
 	if err != nil {


### PR DESCRIPTION
For generating randoms, opensource library gonum is used: https://github.com/gonum/gonum
This library both gives wide opetions and secure randoms
As random content can not be validated, tests are written only for their validators and immutability