### PR TITLE
feat(tensor): add binary operators for element wise min/max

### DIFF
--- a/tensor/internal/cputensor/cputensor.go
+++ b/tensor/internal/cputensor/cputensor.go
@@ -693,6 +693,54 @@ func (t *CPUTensor) Le(u tensor.Tensor) (o tensor.Tensor, err error) {
 	return t.le(cu), nil
 }
 
+func (t *CPUTensor) ElMin(u tensor.Tensor) (o tensor.Tensor, err error) {
+	cu, err := assertCPUTensor(u)
+	if err != nil {
+		err = fmt.Errorf("tensors' device validation failed: %w", err)
+		return
+	}
+
+	err = validator.ValidateBinaryFuncDimsMatch(t.dims, cu.dims)
+	if err != nil {
+		err = fmt.Errorf("tensors' dimension validation failed: %w", err)
+		return
+	}
+
+	r := t.elmin(cu)
+
+	if gradtrack.ForbiddenForAny(t, cu) {
+		r.gctx = gradtrack.Forbidden()
+	} else if gradtrack.RequiredForAny(t, cu) {
+		r.gctx = gradtrack.ElMin(r, t, cu)
+	}
+
+	return r, nil
+}
+
+func (t *CPUTensor) ElMax(u tensor.Tensor) (o tensor.Tensor, err error) {
+	cu, err := assertCPUTensor(u)
+	if err != nil {
+		err = fmt.Errorf("tensors' device validation failed: %w", err)
+		return
+	}
+
+	err = validator.ValidateBinaryFuncDimsMatch(t.dims, cu.dims)
+	if err != nil {
+		err = fmt.Errorf("tensors' dimension validation failed: %w", err)
+		return
+	}
+
+	r := t.elmax(cu)
+
+	if gradtrack.ForbiddenForAny(t, cu) {
+		r.gctx = gradtrack.Forbidden()
+	} else if gradtrack.RequiredForAny(t, cu) {
+		r.gctx = gradtrack.ElMax(r, t, cu)
+	}
+
+	return r, nil
+}
+
 func (t *CPUTensor) Add(u tensor.Tensor) (o tensor.Tensor, err error) {
 	cu, err := assertCPUTensor(u)
 	if err != nil {

--- a/tensor/internal/cputensor/operators.go
+++ b/tensor/internal/cputensor/operators.go
@@ -110,6 +110,14 @@ func (t *CPUTensor) le(u *CPUTensor) (o *CPUTensor) {
 		})
 }
 
+func (t *CPUTensor) elmin(u *CPUTensor) (o *CPUTensor) {
+	return applyBinaryFuncOnTensorsElemWise(t, u, func(a, b float64) float64 { return math.Min(a, b) })
+}
+
+func (t *CPUTensor) elmax(u *CPUTensor) (o *CPUTensor) {
+	return applyBinaryFuncOnTensorsElemWise(t, u, func(a, b float64) float64 { return math.Max(a, b) })
+}
+
 func (t *CPUTensor) add(u *CPUTensor) (o *CPUTensor) {
 	return applyBinaryFuncOnTensorsElemWise(t, u, func(a, b float64) float64 { return a + b })
 }

--- a/tensor/internal/gradtrack/gradients.go
+++ b/tensor/internal/gradtrack/gradients.go
@@ -531,6 +531,72 @@ func Tanh(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
 	}
 }
 
+func ElMin(y tensor.Tensor, a tensor.Tensor, b tensor.Tensor) (gctx *GradContext) {
+	return &GradContext{
+		backEdges: []*backwardEdge{
+			{
+				target: a,
+				gradFn: func() (o tensor.Tensor, err error) {
+					gy := y.Gradient()
+
+					ga, err := y.Eq(a)
+					if err != nil {
+						return
+					}
+
+					return gy.Mul(ga)
+				},
+			},
+			{
+				target: b,
+				gradFn: func() (o tensor.Tensor, err error) {
+					gy := y.Gradient()
+
+					gb, err := y.Eq(b)
+					if err != nil {
+						return
+					}
+
+					return gy.Mul(gb)
+				},
+			},
+		},
+	}
+}
+
+func ElMax(y tensor.Tensor, a tensor.Tensor, b tensor.Tensor) (gctx *GradContext) {
+	return &GradContext{
+		backEdges: []*backwardEdge{
+			{
+				target: a,
+				gradFn: func() (o tensor.Tensor, err error) {
+					gy := y.Gradient()
+
+					ga, err := y.Eq(a)
+					if err != nil {
+						return
+					}
+
+					return gy.Mul(ga)
+				},
+			},
+			{
+				target: b,
+				gradFn: func() (o tensor.Tensor, err error) {
+					gy := y.Gradient()
+
+					gb, err := y.Eq(b)
+					if err != nil {
+						return
+					}
+
+					return gy.Mul(gb)
+				},
+			},
+		},
+	}
+}
+
 func Add(y tensor.Tensor, a tensor.Tensor, b tensor.Tensor) (gctx *GradContext) {
 	return &GradContext{
 		backEdges: []*backwardEdge{

--- a/tensor/tensor.go
+++ b/tensor/tensor.go
@@ -49,6 +49,8 @@ type Tensor interface {
 	Ge(Tensor) (Tensor, error)
 	Lt(Tensor) (Tensor, error)
 	Le(Tensor) (Tensor, error)
+	ElMin(Tensor) (Tensor, error)
+	ElMax(Tensor) (Tensor, error)
 	Add(Tensor) (Tensor, error)
 	Sub(Tensor) (Tensor, error)
 	Mul(Tensor) (Tensor, error)

--- a/tensor/tensor_test/backward_test/gradients_test.go
+++ b/tensor/tensor_test/backward_test/gradients_test.go
@@ -1388,6 +1388,136 @@ func TestTanh(t *testing.T) {
 	})
 }
 
+func TestElMin(t *testing.T) {
+	runTestLogicOnDevices(func(dev tinit.Device) {
+
+		conf := &tinit.Config{
+			Device:    dev,
+			GradTrack: true,
+		}
+
+		/* ------------------------------ */
+
+		a, err := tinit.Full(conf, 3.)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		b, err := tinit.Full(conf, 2.)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		y, err := a.ElMin(b)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = tinit.BackProp(y)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		/* ------------------------------ */
+
+		act := a.Gradient()
+
+		exp, err := tinit.Full(conf, 0.)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+		act = b.Gradient()
+
+		exp, err = tinit.Full(conf, 1.)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+func TestElMax(t *testing.T) {
+	runTestLogicOnDevices(func(dev tinit.Device) {
+
+		conf := &tinit.Config{
+			Device:    dev,
+			GradTrack: true,
+		}
+
+		/* ------------------------------ */
+
+		a, err := tinit.Full(conf, 3.)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		b, err := tinit.Full(conf, 2.)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		y, err := a.ElMax(b)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = tinit.BackProp(y)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		/* ------------------------------ */
+
+		act := a.Gradient()
+
+		exp, err := tinit.Full(conf, 1.)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+		act = b.Gradient()
+
+		exp, err = tinit.Full(conf, 0.)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
 func TestAdd(t *testing.T) {
 	runTestLogicOnDevices(func(dev tinit.Device) {
 

--- a/tensor/tensor_test/forward_test/operators_test.go
+++ b/tensor/tensor_test/forward_test/operators_test.go
@@ -1642,6 +1642,268 @@ func TestLe(t *testing.T) {
 	})
 }
 
+func TestElMin(t *testing.T) {
+	runTestLogicOnDevices(func(dev tinit.Device) {
+
+		conf := &tinit.Config{Device: dev}
+
+		/* ------------------------------ */
+
+		t1, err := tinit.TensorOf(conf, 1.)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t2, err := tinit.TensorOf(conf, 1.)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err := t1.ElMin(t2)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err := tinit.TensorOf(conf, 1.)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+		t1, err = tinit.TensorOf(conf, []float64{0., math.E + 1e-10})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t2, err = tinit.TensorOf(conf, []float64{0., math.E})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = t1.ElMin(t2)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err = tinit.TensorOf(conf, []float64{0., math.E})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+		t1, err = tinit.TensorOf(conf, [][]float64{
+			{1., 2., 3.},
+			{-1., -2., -3.},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t2, err = tinit.TensorOf(conf, [][]float64{
+			{-1., -2., -3.},
+			{1., 2., 3.},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = t1.ElMin(t2)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err = tinit.TensorOf(conf, [][]float64{
+			{-1., -2., -3.},
+			{-1., -2., -3.},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+		t1, err = tinit.Zeros(conf, 1, 2, 3, 4)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t2, err = tinit.Ones(conf, 1, 2, 3, 4)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = t1.ElMin(t2)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err = tinit.Zeros(conf, 1, 2, 3, 4)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+func TestElMax(t *testing.T) {
+	runTestLogicOnDevices(func(dev tinit.Device) {
+
+		conf := &tinit.Config{Device: dev}
+
+		/* ------------------------------ */
+
+		t1, err := tinit.TensorOf(conf, 1.)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t2, err := tinit.TensorOf(conf, 1.)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err := t1.ElMax(t2)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err := tinit.TensorOf(conf, 1.)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+		t1, err = tinit.TensorOf(conf, []float64{0., math.E + 1e-10})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t2, err = tinit.TensorOf(conf, []float64{0., math.E})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = t1.ElMax(t2)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err = tinit.TensorOf(conf, []float64{0., math.E + 1e-10})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+		t1, err = tinit.TensorOf(conf, [][]float64{
+			{1., 2., 3.},
+			{-1., -2., -3.},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t2, err = tinit.TensorOf(conf, [][]float64{
+			{-1., -2., -3.},
+			{1., 2., 3.},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = t1.ElMax(t2)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err = tinit.TensorOf(conf, [][]float64{
+			{1., 2., 3.},
+			{1., 2., 3.},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+		t1, err = tinit.Zeros(conf, 1, 2, 3, 4)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t2, err = tinit.Ones(conf, 1, 2, 3, 4)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = t1.ElMax(t2)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err = tinit.Ones(conf, 1, 2, 3, 4)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
 func TestAdd(t *testing.T) {
 	runTestLogicOnDevices(func(dev tinit.Device) {
 


### PR DESCRIPTION
Due to their binary and compare nature, they are written in binary operator pattern rather than that of tinit.
Designed to support gradient as functions like relu use them.
Grad mechanism takes the same inspiration as min/max reducers.