### PR TITLE
feat(tensor): add ResetGradContext to tensor interface

### DIFF
--- a/tensor/internal/cputensor/cputensor.go
+++ b/tensor/internal/cputensor/cputensor.go
@@ -18,10 +18,7 @@ func Full(dims []int, value float64, withGrad bool) (o tensor.Tensor, err error)
 	}
 
 	r := constTensor(value, dims)
-
-	if withGrad {
-		r.gctx = gradtrack.Root()
-	}
+	r.gctx = gradtrack.NewGradContext(withGrad)
 
 	return r, nil
 }
@@ -42,10 +39,7 @@ func Eye(n int, withGrad bool) (o tensor.Tensor, err error) {
 	}
 
 	r := eyeMatrix(n)
-
-	if withGrad {
-		r.gctx = gradtrack.Root()
-	}
+	r.gctx = gradtrack.NewGradContext(withGrad)
 
 	return r, nil
 }
@@ -64,10 +58,7 @@ func RandU(dims []int, l, u float64, withGrad bool) (o tensor.Tensor, err error)
 	}
 
 	r := uniformRandomTensor(l, u, dims)
-
-	if withGrad {
-		r.gctx = gradtrack.Root()
-	}
+	r.gctx = gradtrack.NewGradContext(withGrad)
 
 	return r, nil
 }
@@ -86,10 +77,7 @@ func RandN(dims []int, u, s float64, withGrad bool) (o tensor.Tensor, err error)
 	}
 
 	r := normalRandomTensor(u, s, dims)
-
-	if withGrad {
-		r.gctx = gradtrack.Root()
-	}
+	r.gctx = gradtrack.NewGradContext(withGrad)
 
 	return r, nil
 }
@@ -102,10 +90,7 @@ func TensorOf(data any, withGrad bool) (o tensor.Tensor, err error) {
 	}
 
 	r := initTensorFromData(data)
-
-	if withGrad {
-		r.gctx = gradtrack.Root()
-	}
+	r.gctx = gradtrack.NewGradContext(withGrad)
 
 	return r, nil
 }
@@ -129,12 +114,7 @@ func Concat(ts []tensor.Tensor, dim int) (o tensor.Tensor, err error) {
 	}
 
 	r := initConcatResultTensor(cus, dim)
-
-	if gradtrack.ForbiddenForAny(ts...) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(ts...) {
-		r.gctx = gradtrack.Concat(r, ts, dim)
-	}
+	r.gctx = gradtrack.Concat(r, ts, dim)
 
 	return r, nil
 }
@@ -169,12 +149,7 @@ func (t *CPUTensor) Slice(index []tensor.Range) (o tensor.Tensor, err error) {
 	}
 
 	r := t.slice(index)
-
-	if gradtrack.ForbiddenForAny(t) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t) {
-		r.gctx = gradtrack.Slice(r, t, index)
-	}
+	r.gctx = gradtrack.Slice(r, t, index)
 
 	return r, nil
 }
@@ -193,12 +168,7 @@ func (t *CPUTensor) Patch(index []tensor.Range, u tensor.Tensor) (o tensor.Tenso
 	}
 
 	r := t.patch(index, cu)
-
-	if gradtrack.ForbiddenForAny(t, u) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t, u) {
-		r.gctx = gradtrack.Patch(r, t, u, index)
-	}
+	r.gctx = gradtrack.Patch(r, t, u, index)
 
 	return r, nil
 }
@@ -211,12 +181,7 @@ func (t *CPUTensor) Transpose() (o tensor.Tensor, err error) {
 	}
 
 	r := t.transpose()
-
-	if gradtrack.ForbiddenForAny(t) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t) {
-		r.gctx = gradtrack.Transpose(r, t)
-	}
+	r.gctx = gradtrack.Transpose(r, t)
 
 	return r, nil
 }
@@ -235,12 +200,7 @@ func (t *CPUTensor) Reshape(shape []int) (o tensor.Tensor, err error) {
 	}
 
 	r := t.reshape(shape)
-
-	if gradtrack.ForbiddenForAny(t) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t) {
-		r.gctx = gradtrack.Reshape(r, t)
-	}
+	r.gctx = gradtrack.Reshape(r, t)
 
 	return r, nil
 }
@@ -253,12 +213,7 @@ func (t *CPUTensor) UnSqueeze(dim int) (o tensor.Tensor, err error) {
 	}
 
 	r := t.unSqueeze(dim)
-
-	if gradtrack.ForbiddenForAny(t) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t) {
-		r.gctx = gradtrack.UnSqueeze(r, t)
-	}
+	r.gctx = gradtrack.UnSqueeze(r, t)
 
 	return r, nil
 }
@@ -271,12 +226,7 @@ func (t *CPUTensor) Squeeze(dim int) (o tensor.Tensor, err error) {
 	}
 
 	r := t.squeeze(dim)
-
-	if gradtrack.ForbiddenForAny(t) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t) {
-		r.gctx = gradtrack.Squeeze(r, t)
-	}
+	r.gctx = gradtrack.Squeeze(r, t)
 
 	return r, nil
 }
@@ -289,12 +239,7 @@ func (t *CPUTensor) Flatten(fromDim int) (o tensor.Tensor, err error) {
 	}
 
 	r := t.flatten(fromDim)
-
-	if gradtrack.ForbiddenForAny(t) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t) {
-		r.gctx = gradtrack.Flatten(r, t)
-	}
+	r.gctx = gradtrack.Flatten(r, t)
 
 	return r, nil
 }
@@ -313,12 +258,7 @@ func (t *CPUTensor) Broadcast(shape []int) (o tensor.Tensor, err error) {
 	}
 
 	r := t.broadcast(shape)
-
-	if gradtrack.ForbiddenForAny(t) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t) {
-		r.gctx = gradtrack.Broadcast(r, t)
-	}
+	r.gctx = gradtrack.Broadcast(r, t)
 
 	return r, nil
 }
@@ -359,12 +299,7 @@ func (t *CPUTensor) SumAlong(dim int) (o tensor.Tensor, err error) {
 	}
 
 	r := t.sumAlong(dim)
-
-	if gradtrack.ForbiddenForAny(t) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t) {
-		r.gctx = gradtrack.SumAlong(r, t, dim)
-	}
+	r.gctx = gradtrack.SumAlong(r, t, dim)
 
 	return r, nil
 }
@@ -377,12 +312,7 @@ func (t *CPUTensor) MaxAlong(dim int) (o tensor.Tensor, err error) {
 	}
 
 	r := t.maxAlong(dim)
-
-	if gradtrack.ForbiddenForAny(t) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t) {
-		r.gctx = gradtrack.MaxAlong(r, t, dim)
-	}
+	r.gctx = gradtrack.MaxAlong(r, t, dim)
 
 	return r, nil
 }
@@ -395,12 +325,7 @@ func (t *CPUTensor) MinAlong(dim int) (o tensor.Tensor, err error) {
 	}
 
 	r := t.minAlong(dim)
-
-	if gradtrack.ForbiddenForAny(t) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t) {
-		r.gctx = gradtrack.MinAlong(r, t, dim)
-	}
+	r.gctx = gradtrack.MinAlong(r, t, dim)
 
 	return r, nil
 }
@@ -413,12 +338,7 @@ func (t *CPUTensor) AvgAlong(dim int) (o tensor.Tensor, err error) {
 	}
 
 	r := t.avgAlong(dim)
-
-	if gradtrack.ForbiddenForAny(t) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t) {
-		r.gctx = gradtrack.AvgAlong(r, t, dim)
-	}
+	r.gctx = gradtrack.AvgAlong(r, t, dim)
 
 	return r, nil
 }
@@ -431,12 +351,7 @@ func (t *CPUTensor) VarAlong(dim int) (o tensor.Tensor, err error) {
 	}
 
 	r := t.varAlong(dim)
-
-	if gradtrack.ForbiddenForAny(t) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t) {
-		r.gctx = gradtrack.VarAlong(r, t, dim)
-	}
+	r.gctx = gradtrack.VarAlong(r, t, dim)
 
 	return r, nil
 }
@@ -449,12 +364,7 @@ func (t *CPUTensor) StdAlong(dim int) (o tensor.Tensor, err error) {
 	}
 
 	r := t.stdAlong(dim)
-
-	if gradtrack.ForbiddenForAny(t) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t) {
-		r.gctx = gradtrack.StdAlong(r, t, dim)
-	}
+	r.gctx = gradtrack.StdAlong(r, t, dim)
 
 	return r, nil
 }
@@ -467,133 +377,68 @@ func (t *CPUTensor) MeanAlong(dim int) (o tensor.Tensor, err error) {
 	}
 
 	r := t.meanAlong(dim)
-
-	if gradtrack.ForbiddenForAny(t) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t) {
-		r.gctx = gradtrack.MeanAlong(r, t, dim)
-	}
+	r.gctx = gradtrack.MeanAlong(r, t, dim)
 
 	return r, nil
 }
 
 func (t *CPUTensor) Scale(u float64) (o tensor.Tensor) {
 	r := t.scale(u)
-
-	if gradtrack.ForbiddenForAny(t) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t) {
-		r.gctx = gradtrack.Scale(r, t, u)
-	}
-
+	r.gctx = gradtrack.Scale(r, t, u)
 	return r
 }
 
 func (t *CPUTensor) Pow(u float64) (o tensor.Tensor) {
 	r := t.pow(u)
-
-	if gradtrack.ForbiddenForAny(t) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t) {
-		r.gctx = gradtrack.Pow(r, t, u)
-	}
-
+	r.gctx = gradtrack.Pow(r, t, u)
 	return r
 }
 
 func (t *CPUTensor) Exp() (o tensor.Tensor) {
 	r := t.exp()
-
-	if gradtrack.ForbiddenForAny(t) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t) {
-		r.gctx = gradtrack.Exp(r, t)
-	}
-
+	r.gctx = gradtrack.Exp(r, t)
 	return r
 }
 
 func (t *CPUTensor) Log() (o tensor.Tensor) {
 	r := t.log()
-
-	if gradtrack.ForbiddenForAny(t) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t) {
-		r.gctx = gradtrack.Log(r, t)
-	}
-
+	r.gctx = gradtrack.Log(r, t)
 	return r
 }
 
 func (t *CPUTensor) Sin() (o tensor.Tensor) {
 	r := t.sin()
-
-	if gradtrack.ForbiddenForAny(t) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t) {
-		r.gctx = gradtrack.Sin(r, t)
-	}
-
+	r.gctx = gradtrack.Sin(r, t)
 	return r
 }
 
 func (t *CPUTensor) Cos() (o tensor.Tensor) {
 	r := t.cos()
-
-	if gradtrack.ForbiddenForAny(t) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t) {
-		r.gctx = gradtrack.Cos(r, t)
-	}
-
+	r.gctx = gradtrack.Cos(r, t)
 	return r
 }
 
 func (t *CPUTensor) Tan() (o tensor.Tensor) {
 	r := t.tan()
-
-	if gradtrack.ForbiddenForAny(t) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t) {
-		r.gctx = gradtrack.Tan(r, t)
-	}
-
+	r.gctx = gradtrack.Tan(r, t)
 	return r
 }
 
 func (t *CPUTensor) Sinh() (o tensor.Tensor) {
 	r := t.sinh()
-
-	if gradtrack.ForbiddenForAny(t) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t) {
-		r.gctx = gradtrack.Sinh(r, t)
-	}
-
+	r.gctx = gradtrack.Sinh(r, t)
 	return r
 }
 
 func (t *CPUTensor) Cosh() (o tensor.Tensor) {
 	r := t.cosh()
-
-	if gradtrack.ForbiddenForAny(t) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t) {
-		r.gctx = gradtrack.Cosh(r, t)
-	}
-
+	r.gctx = gradtrack.Cosh(r, t)
 	return r
 }
 
 func (t *CPUTensor) Tanh() (o tensor.Tensor) {
 	r := t.tanh()
-
-	if gradtrack.ForbiddenForAny(t) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t) {
-		r.gctx = gradtrack.Tanh(r, t)
-	}
-
+	r.gctx = gradtrack.Tanh(r, t)
 	return r
 }
 
@@ -610,7 +455,10 @@ func (t *CPUTensor) Eq(u tensor.Tensor) (o tensor.Tensor, err error) {
 		return
 	}
 
-	return t.eq(cu), nil
+	r := t.eq(cu)
+	r.gctx = gradtrack.NewGradContext(false)
+
+	return r, nil
 }
 
 func (t *CPUTensor) Ne(u tensor.Tensor) (o tensor.Tensor, err error) {
@@ -626,7 +474,10 @@ func (t *CPUTensor) Ne(u tensor.Tensor) (o tensor.Tensor, err error) {
 		return
 	}
 
-	return t.ne(cu), nil
+	r := t.ne(cu)
+	r.gctx = gradtrack.NewGradContext(false)
+
+	return r, nil
 }
 
 func (t *CPUTensor) Gt(u tensor.Tensor) (o tensor.Tensor, err error) {
@@ -642,7 +493,10 @@ func (t *CPUTensor) Gt(u tensor.Tensor) (o tensor.Tensor, err error) {
 		return
 	}
 
-	return t.gt(cu), nil
+	r := t.gt(cu)
+	r.gctx = gradtrack.NewGradContext(false)
+
+	return r, nil
 }
 
 func (t *CPUTensor) Ge(u tensor.Tensor) (o tensor.Tensor, err error) {
@@ -658,7 +512,10 @@ func (t *CPUTensor) Ge(u tensor.Tensor) (o tensor.Tensor, err error) {
 		return
 	}
 
-	return t.ge(cu), nil
+	r := t.ge(cu)
+	r.gctx = gradtrack.NewGradContext(false)
+
+	return r, nil
 }
 
 func (t *CPUTensor) Lt(u tensor.Tensor) (o tensor.Tensor, err error) {
@@ -674,7 +531,10 @@ func (t *CPUTensor) Lt(u tensor.Tensor) (o tensor.Tensor, err error) {
 		return
 	}
 
-	return t.lt(cu), nil
+	r := t.lt(cu)
+	r.gctx = gradtrack.NewGradContext(false)
+
+	return r, nil
 }
 
 func (t *CPUTensor) Le(u tensor.Tensor) (o tensor.Tensor, err error) {
@@ -690,7 +550,10 @@ func (t *CPUTensor) Le(u tensor.Tensor) (o tensor.Tensor, err error) {
 		return
 	}
 
-	return t.le(cu), nil
+	r := t.le(cu)
+	r.gctx = gradtrack.NewGradContext(false)
+
+	return r, nil
 }
 
 func (t *CPUTensor) ElMax(u tensor.Tensor) (o tensor.Tensor, err error) {
@@ -707,12 +570,7 @@ func (t *CPUTensor) ElMax(u tensor.Tensor) (o tensor.Tensor, err error) {
 	}
 
 	r := t.elmax(cu)
-
-	if gradtrack.ForbiddenForAny(t, cu) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t, cu) {
-		r.gctx = gradtrack.ElMax(r, t, cu)
-	}
+	r.gctx = gradtrack.ElMax(r, t, cu)
 
 	return r, nil
 }
@@ -731,12 +589,7 @@ func (t *CPUTensor) ElMin(u tensor.Tensor) (o tensor.Tensor, err error) {
 	}
 
 	r := t.elmin(cu)
-
-	if gradtrack.ForbiddenForAny(t, cu) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(t, cu) {
-		r.gctx = gradtrack.ElMin(r, t, cu)
-	}
+	r.gctx = gradtrack.ElMin(r, t, cu)
 
 	return r, nil
 }
@@ -755,12 +608,7 @@ func (t *CPUTensor) Add(u tensor.Tensor) (o tensor.Tensor, err error) {
 	}
 
 	r := ct1.add(ct2)
-
-	if gradtrack.ForbiddenForAny(ct1, ct2) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(ct1, ct2) {
-		r.gctx = gradtrack.Add(r, ct1, ct2)
-	}
+	r.gctx = gradtrack.Add(r, ct1, ct2)
 
 	return r, nil
 }
@@ -779,12 +627,7 @@ func (t *CPUTensor) Sub(u tensor.Tensor) (o tensor.Tensor, err error) {
 	}
 
 	r := ct1.sub(ct2)
-
-	if gradtrack.ForbiddenForAny(ct1, ct2) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(ct1, ct2) {
-		r.gctx = gradtrack.Sub(r, ct1, ct2)
-	}
+	r.gctx = gradtrack.Sub(r, ct1, ct2)
 
 	return r, nil
 }
@@ -803,12 +646,7 @@ func (t *CPUTensor) Mul(u tensor.Tensor) (o tensor.Tensor, err error) {
 	}
 
 	r := ct1.mul(ct2)
-
-	if gradtrack.ForbiddenForAny(ct1, ct2) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(ct1, ct2) {
-		r.gctx = gradtrack.Mul(r, ct1, ct2)
-	}
+	r.gctx = gradtrack.Mul(r, ct1, ct2)
 
 	return r, nil
 }
@@ -827,12 +665,7 @@ func (t *CPUTensor) Div(u tensor.Tensor) (o tensor.Tensor, err error) {
 	}
 
 	r := ct1.div(ct2)
-
-	if gradtrack.ForbiddenForAny(ct1, ct2) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(ct1, ct2) {
-		r.gctx = gradtrack.Div(r, ct1, ct2)
-	}
+	r.gctx = gradtrack.Div(r, ct1, ct2)
 
 	return r, nil
 }
@@ -857,12 +690,7 @@ func (t *CPUTensor) Dot(u tensor.Tensor) (o tensor.Tensor, err error) {
 	}
 
 	r := ct1.dot(ct2)
-
-	if gradtrack.ForbiddenForAny(ct1, ct2) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(ct1, ct2) {
-		r.gctx = gradtrack.Dot(r, ct1, ct2)
-	}
+	r.gctx = gradtrack.Dot(r, ct1, ct2)
 
 	return r, nil
 }
@@ -887,12 +715,7 @@ func (t *CPUTensor) MatMul(u tensor.Tensor) (o tensor.Tensor, err error) {
 	}
 
 	r := ct1.matMul(ct2)
-
-	if gradtrack.ForbiddenForAny(ct1, ct2) {
-		r.gctx = gradtrack.Forbidden()
-	} else if gradtrack.RequiredForAny(ct1, ct2) {
-		r.gctx = gradtrack.MatMul(r, ct1, ct2)
-	}
+	r.gctx = gradtrack.MatMul(r, ct1, ct2)
 
 	return r, nil
 }
@@ -917,10 +740,10 @@ func (t *CPUTensor) GradContext() (gctx any) {
 	return t.gctx
 }
 
-func (t *CPUTensor) Gradient() (g tensor.Tensor) {
-	return t.gctx.Grad()
+func (t *CPUTensor) ResetGradContext(tracked bool) {
+	t.gctx = gradtrack.NewGradContext(tracked)
 }
 
-func (t *CPUTensor) Detach() (o tensor.Tensor) {
-	return t.slice(nil)
+func (t *CPUTensor) Gradient() (g tensor.Tensor) {
+	return t.gctx.Gradient()
 }

--- a/tensor/internal/gradtrack/gradients.go
+++ b/tensor/internal/gradtrack/gradients.go
@@ -2,15 +2,14 @@ package gradtrack
 
 import "github.com/sahandsafizadeh/qeep/tensor"
 
-func Root() (gctx *GradContext) {
-	return new(GradContext)
-}
-
-func Forbidden() (gctx *GradContext) {
-	return &GradContext{trackForbidden: true}
-}
-
 func Concat(y tensor.Tensor, xs []tensor.Tensor, dim int) (gctx *GradContext) {
+	if anyIsBPDirty(xs...) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(xs...) {
+		return NewGradContext(false)
+	}
+
 	backEdges := make([]*backwardEdge, len(xs))
 
 	var base int
@@ -33,11 +32,22 @@ func Concat(y tensor.Tensor, xs []tensor.Tensor, dim int) (gctx *GradContext) {
 		}
 	}
 
-	return &GradContext{backEdges: backEdges}
+	return &GradContext{
+		tracked:   true,
+		backEdges: backEdges,
+	}
 }
 
 func Slice(y tensor.Tensor, x tensor.Tensor, index []tensor.Range) (gctx *GradContext) {
+	if anyIsBPDirty(x) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(x) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: x,
@@ -50,7 +60,15 @@ func Slice(y tensor.Tensor, x tensor.Tensor, index []tensor.Range) (gctx *GradCo
 }
 
 func Patch(y tensor.Tensor, x tensor.Tensor, p tensor.Tensor, index []tensor.Range) (gctx *GradContext) {
+	if anyIsBPDirty(x, p) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(x, p) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: x,
@@ -69,7 +87,15 @@ func Patch(y tensor.Tensor, x tensor.Tensor, p tensor.Tensor, index []tensor.Ran
 }
 
 func Transpose(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
+	if anyIsBPDirty(x) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(x) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: x,
@@ -82,7 +108,15 @@ func Transpose(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
 }
 
 func Reshape(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
+	if anyIsBPDirty(x) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(x) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: x,
@@ -95,7 +129,15 @@ func Reshape(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
 }
 
 func UnSqueeze(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
+	if anyIsBPDirty(x) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(x) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: x,
@@ -108,7 +150,15 @@ func UnSqueeze(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
 }
 
 func Squeeze(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
+	if anyIsBPDirty(x) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(x) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: x,
@@ -121,7 +171,15 @@ func Squeeze(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
 }
 
 func Flatten(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
+	if anyIsBPDirty(x) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(x) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: x,
@@ -134,7 +192,15 @@ func Flatten(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
 }
 
 func Broadcast(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
+	if anyIsBPDirty(x) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(x) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: x,
@@ -181,7 +247,15 @@ func Broadcast(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
 }
 
 func SumAlong(y tensor.Tensor, x tensor.Tensor, dim int) (gctx *GradContext) {
+	if anyIsBPDirty(x) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(x) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: x,
@@ -194,7 +268,15 @@ func SumAlong(y tensor.Tensor, x tensor.Tensor, dim int) (gctx *GradContext) {
 }
 
 func MaxAlong(y tensor.Tensor, x tensor.Tensor, dim int) (gctx *GradContext) {
+	if anyIsBPDirty(x) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(x) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: x,
@@ -222,7 +304,15 @@ func MaxAlong(y tensor.Tensor, x tensor.Tensor, dim int) (gctx *GradContext) {
 }
 
 func MinAlong(y tensor.Tensor, x tensor.Tensor, dim int) (gctx *GradContext) {
+	if anyIsBPDirty(x) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(x) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: x,
@@ -250,7 +340,15 @@ func MinAlong(y tensor.Tensor, x tensor.Tensor, dim int) (gctx *GradContext) {
 }
 
 func AvgAlong(y tensor.Tensor, x tensor.Tensor, dim int) (gctx *GradContext) {
+	if anyIsBPDirty(x) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(x) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: x,
@@ -270,7 +368,15 @@ func AvgAlong(y tensor.Tensor, x tensor.Tensor, dim int) (gctx *GradContext) {
 }
 
 func VarAlong(y tensor.Tensor, x tensor.Tensor, dim int) (gctx *GradContext) {
+	if anyIsBPDirty(x) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(x) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: x,
@@ -310,7 +416,15 @@ func VarAlong(y tensor.Tensor, x tensor.Tensor, dim int) (gctx *GradContext) {
 }
 
 func StdAlong(y tensor.Tensor, x tensor.Tensor, dim int) (gctx *GradContext) {
+	if anyIsBPDirty(x) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(x) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: x,
@@ -360,7 +474,15 @@ func StdAlong(y tensor.Tensor, x tensor.Tensor, dim int) (gctx *GradContext) {
 }
 
 func MeanAlong(y tensor.Tensor, x tensor.Tensor, dim int) (gctx *GradContext) {
+	if anyIsBPDirty(x) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(x) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: x,
@@ -380,7 +502,15 @@ func MeanAlong(y tensor.Tensor, x tensor.Tensor, dim int) (gctx *GradContext) {
 }
 
 func Scale(y tensor.Tensor, x tensor.Tensor, a float64) (gctx *GradContext) {
+	if anyIsBPDirty(x) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(x) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: x,
@@ -393,7 +523,15 @@ func Scale(y tensor.Tensor, x tensor.Tensor, a float64) (gctx *GradContext) {
 }
 
 func Pow(y tensor.Tensor, x tensor.Tensor, a float64) (gctx *GradContext) {
+	if anyIsBPDirty(x) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(x) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: x,
@@ -410,7 +548,15 @@ func Pow(y tensor.Tensor, x tensor.Tensor, a float64) (gctx *GradContext) {
 }
 
 func Exp(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
+	if anyIsBPDirty(x) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(x) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: x,
@@ -423,7 +569,15 @@ func Exp(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
 }
 
 func Log(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
+	if anyIsBPDirty(x) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(x) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: x,
@@ -436,7 +590,15 @@ func Log(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
 }
 
 func Sin(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
+	if anyIsBPDirty(x) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(x) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: x,
@@ -452,7 +614,15 @@ func Sin(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
 }
 
 func Cos(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
+	if anyIsBPDirty(x) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(x) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: x,
@@ -468,7 +638,15 @@ func Cos(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
 }
 
 func Tan(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
+	if anyIsBPDirty(x) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(x) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: x,
@@ -484,7 +662,15 @@ func Tan(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
 }
 
 func Sinh(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
+	if anyIsBPDirty(x) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(x) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: x,
@@ -500,7 +686,15 @@ func Sinh(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
 }
 
 func Cosh(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
+	if anyIsBPDirty(x) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(x) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: x,
@@ -516,7 +710,15 @@ func Cosh(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
 }
 
 func Tanh(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
+	if anyIsBPDirty(x) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(x) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: x,
@@ -532,7 +734,15 @@ func Tanh(y tensor.Tensor, x tensor.Tensor) (gctx *GradContext) {
 }
 
 func ElMax(y tensor.Tensor, a tensor.Tensor, b tensor.Tensor) (gctx *GradContext) {
+	if anyIsBPDirty(a, b) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(a, b) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: a,
@@ -585,7 +795,15 @@ func ElMax(y tensor.Tensor, a tensor.Tensor, b tensor.Tensor) (gctx *GradContext
 }
 
 func ElMin(y tensor.Tensor, a tensor.Tensor, b tensor.Tensor) (gctx *GradContext) {
+	if anyIsBPDirty(a, b) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(a, b) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: a,
@@ -638,7 +856,15 @@ func ElMin(y tensor.Tensor, a tensor.Tensor, b tensor.Tensor) (gctx *GradContext
 }
 
 func Add(y tensor.Tensor, a tensor.Tensor, b tensor.Tensor) (gctx *GradContext) {
+	if anyIsBPDirty(a, b) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(a, b) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: a,
@@ -657,7 +883,15 @@ func Add(y tensor.Tensor, a tensor.Tensor, b tensor.Tensor) (gctx *GradContext) 
 }
 
 func Sub(y tensor.Tensor, a tensor.Tensor, b tensor.Tensor) (gctx *GradContext) {
+	if anyIsBPDirty(a, b) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(a, b) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: a,
@@ -676,7 +910,15 @@ func Sub(y tensor.Tensor, a tensor.Tensor, b tensor.Tensor) (gctx *GradContext) 
 }
 
 func Mul(y tensor.Tensor, a tensor.Tensor, b tensor.Tensor) (gctx *GradContext) {
+	if anyIsBPDirty(a, b) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(a, b) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: a,
@@ -695,7 +937,15 @@ func Mul(y tensor.Tensor, a tensor.Tensor, b tensor.Tensor) (gctx *GradContext) 
 }
 
 func Div(y tensor.Tensor, a tensor.Tensor, b tensor.Tensor) (gctx *GradContext) {
+	if anyIsBPDirty(a, b) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(a, b) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: a,
@@ -724,7 +974,15 @@ func Div(y tensor.Tensor, a tensor.Tensor, b tensor.Tensor) (gctx *GradContext) 
 }
 
 func Dot(y tensor.Tensor, a tensor.Tensor, b tensor.Tensor) (gctx *GradContext) {
+	if anyIsBPDirty(a, b) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(a, b) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: a,
@@ -743,7 +1001,15 @@ func Dot(y tensor.Tensor, a tensor.Tensor, b tensor.Tensor) (gctx *GradContext) 
 }
 
 func MatMul(y tensor.Tensor, a tensor.Tensor, b tensor.Tensor) (gctx *GradContext) {
+	if anyIsBPDirty(a, b) {
+		return NewDirtyGradContext()
+	}
+	if nonIsTracked(a, b) {
+		return NewGradContext(false)
+	}
+
 	return &GradContext{
+		tracked: true,
 		backEdges: []*backwardEdge{
 			{
 				target: a,

--- a/tensor/internal/gradtrack/types.go
+++ b/tensor/internal/gradtrack/types.go
@@ -3,9 +3,10 @@ package gradtrack
 import "github.com/sahandsafizadeh/qeep/tensor"
 
 type GradContext struct {
-	grad           tensor.Tensor
-	backEdges      []*backwardEdge
-	trackForbidden bool
+	tracked   bool
+	bpdirty   bool
+	gradient  tensor.Tensor
+	backEdges []*backwardEdge
 }
 
 type backwardEdge struct {

--- a/tensor/tensor.go
+++ b/tensor/tensor.go
@@ -61,8 +61,8 @@ type Tensor interface {
 
 	/*--------------- gradients ---------------*/
 	GradContext() any
+	ResetGradContext(bool)
 	Gradient() Tensor
-	Detach() Tensor
 }
 
 type Range struct {


### PR DESCRIPTION
- Feat!: add `ResetGradContext` to tensor interface.
In a model, each tensor requires to change its `GradContext` behavior in different batches/epochs. For instance, in prediction mode, no tensor should track the gradients. While in train mode, most of the tensors track gradients but some might not because of ***pre-training***. Also, for the sake of ***fine-tuning*** and nature of models like ***GAN***s, tensors must be able to switch between these behaviors whenever needed.
- Refactor: replace `forbidden` with more meaningfull `bpdirty`.
`bpdirty` stands for ***back-propagation dirty***. In back-propagation, a tensor can be visited many times leading to gradient accumulation. The first time it's visited, it would be marked as *dirty*. Thereafter, any calculation that uses it would not track gradients anymore.
- Fix: now *every* tensor must have `GradContext`.
The behavior of gradient tracking is now defined by two boolean properties: `tracked` and `bpdirty`. This is the reason that methods like `Eq`, which are not differentiable by nature, now initialize `GradContext` of their result.
- Refactor: move *forbidden*/*required* logic into gradtrack package.