### PR TITLE
feat(component): add neural network components

### DIFF
--- a/component/initializers/full.go
+++ b/component/initializers/full.go
@@ -1,0 +1,40 @@
+package initializers
+
+import "github.com/sahandsafizadeh/qeep/tensor"
+
+type Full struct {
+	value float64
+}
+
+type FullConfig struct {
+	Value float64
+}
+
+const fullDefaultValue = 0.
+
+func NewFull(conf *FullConfig) (c *Full) {
+	conf = toValidFullConfig(conf)
+
+	return &Full{
+		value: conf.Value,
+	}
+}
+
+func (c *Full) Init(shape []int) (x tensor.Tensor, err error) {
+	return tensor.Full(shape, c.value, tensorInitConf())
+}
+
+/* ----- helpers ----- */
+
+func toValidFullConfig(iconf *FullConfig) (conf *FullConfig) {
+	if iconf == nil {
+		iconf = &FullConfig{
+			Value: fullDefaultValue,
+		}
+	}
+
+	conf = new(FullConfig)
+	*conf = *iconf
+
+	return conf
+}

--- a/component/initializers/full_test.go
+++ b/component/initializers/full_test.go
@@ -1,0 +1,55 @@
+package initializers_test
+
+import (
+	"testing"
+
+	"github.com/sahandsafizadeh/qeep/component/initializers"
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+func TestFull(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(_ tensor.Device) {
+
+		initializer := initializers.NewFull(nil)
+
+		/* ------------------------------ */
+
+		x, err := initializer.Init([]int{32, 32})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		shape := x.Shape()
+		if !shapesEqual(shape, []int{32, 32}) {
+			t.Fatalf("expected tensor to have shape [32, 32], got %v", shape)
+		}
+
+		err = tensor.BackPropagate(x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if x.Gradient() == nil {
+			t.Fatalf("expected gradient not to be nil")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+/* ----- helpers ----- */
+
+func shapesEqual(s1, s2 []int) (ok bool) {
+	if len(s1) != len(s2) {
+		return false
+	}
+
+	for i := 0; i < len(s1); i++ {
+		if s1[i] != s2[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/component/initializers/he_normal.go
+++ b/component/initializers/he_normal.go
@@ -1,0 +1,52 @@
+package initializers
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+type HeNormal struct {
+	fanIn int
+}
+
+type HeNormalConfig struct {
+	FanIn int
+}
+
+func NewHeNormal(conf *HeNormalConfig) (c *HeNormal, err error) {
+	conf, err = toValidHeNormalConfig(conf)
+	if err != nil {
+		err = fmt.Errorf("HeNormal config data validation failed: %w", err)
+		return
+	}
+
+	return &HeNormal{
+		fanIn: conf.FanIn,
+	}, nil
+}
+
+func (c *HeNormal) Init(shape []int) (x tensor.Tensor, err error) {
+	s := math.Sqrt(2. / float64(c.fanIn))
+	return tensor.RandN(shape, 0., s, tensorInitConf())
+}
+
+/* ----- helpers ----- */
+
+func toValidHeNormalConfig(iconf *HeNormalConfig) (conf *HeNormalConfig, err error) {
+	if iconf == nil {
+		err = fmt.Errorf("expected config not to be nil")
+		return
+	}
+
+	conf = new(HeNormalConfig)
+	*conf = *iconf
+
+	if conf.FanIn <= 0 {
+		err = fmt.Errorf("expected 'FanIn' to be positive: got (%d)", conf.FanIn)
+		return
+	}
+
+	return conf, nil
+}

--- a/component/initializers/he_normal_test.go
+++ b/component/initializers/he_normal_test.go
@@ -1,0 +1,73 @@
+package initializers_test
+
+import (
+	"testing"
+
+	"github.com/sahandsafizadeh/qeep/component/initializers"
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+func TestHeNormal(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(_ tensor.Device) {
+
+		initializer, err := initializers.NewHeNormal(&initializers.HeNormalConfig{FanIn: 16})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		/* ------------------------------ */
+
+		x, err := initializer.Init([]int{32, 32})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		shape := x.Shape()
+		if !shapesEqual(shape, []int{32, 32}) {
+			t.Fatalf("expected tensor to have shape [32, 32], got %v", shape)
+		}
+
+		err = tensor.BackPropagate(x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if x.Gradient() == nil {
+			t.Fatalf("expected gradient not to be nil")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+func TestValidationHeNormal(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(_ tensor.Device) {
+
+		/* ------------------------------ */
+
+		_, err := initializers.NewHeNormal(nil)
+		if err == nil {
+			t.Fatalf("expected error because of nil input config")
+		} else if err.Error() != "HeNormal config data validation failed: expected config not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = initializers.NewHeNormal(&initializers.HeNormalConfig{FanIn: 0})
+		if err == nil {
+			t.Fatalf("expected error because of non-positive 'FanIn'")
+		} else if err.Error() != "HeNormal config data validation failed: expected 'FanIn' to be positive: got (0)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = initializers.NewHeNormal(&initializers.HeNormalConfig{FanIn: -1})
+		if err == nil {
+			t.Fatalf("expected error because of non-positive 'FanIn'")
+		} else if err.Error() != "HeNormal config data validation failed: expected 'FanIn' to be positive: got (-1)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		/* ------------------------------ */
+
+	})
+}

--- a/component/initializers/he_uniform.go
+++ b/component/initializers/he_uniform.go
@@ -1,0 +1,52 @@
+package initializers
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+type HeUniform struct {
+	fanIn int
+}
+
+type HeUniformConfig struct {
+	FanIn int
+}
+
+func NewHeUniform(conf *HeUniformConfig) (c *HeUniform, err error) {
+	conf, err = toValidHeUniformConfig(conf)
+	if err != nil {
+		err = fmt.Errorf("HeUniform config data validation failed: %w", err)
+		return
+	}
+
+	return &HeUniform{
+		fanIn: conf.FanIn,
+	}, nil
+}
+
+func (c *HeUniform) Init(shape []int) (x tensor.Tensor, err error) {
+	r := math.Sqrt(6. / float64(c.fanIn))
+	return tensor.RandU(shape, -r, r, tensorInitConf())
+}
+
+/* ----- helpers ----- */
+
+func toValidHeUniformConfig(iconf *HeUniformConfig) (conf *HeUniformConfig, err error) {
+	if iconf == nil {
+		err = fmt.Errorf("expected config not to be nil")
+		return
+	}
+
+	conf = new(HeUniformConfig)
+	*conf = *iconf
+
+	if conf.FanIn <= 0 {
+		err = fmt.Errorf("expected 'FanIn' to be positive: got (%d)", conf.FanIn)
+		return
+	}
+
+	return conf, nil
+}

--- a/component/initializers/he_uniform_test.go
+++ b/component/initializers/he_uniform_test.go
@@ -1,0 +1,73 @@
+package initializers_test
+
+import (
+	"testing"
+
+	"github.com/sahandsafizadeh/qeep/component/initializers"
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+func TestHeUniform(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(_ tensor.Device) {
+
+		initializer, err := initializers.NewHeUniform(&initializers.HeUniformConfig{FanIn: 16})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		/* ------------------------------ */
+
+		x, err := initializer.Init([]int{32, 32})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		shape := x.Shape()
+		if !shapesEqual(shape, []int{32, 32}) {
+			t.Fatalf("expected tensor to have shape [32, 32], got %v", shape)
+		}
+
+		err = tensor.BackPropagate(x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if x.Gradient() == nil {
+			t.Fatalf("expected gradient not to be nil")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+func TestValidationHeUniform(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(_ tensor.Device) {
+
+		/* ------------------------------ */
+
+		_, err := initializers.NewHeUniform(nil)
+		if err == nil {
+			t.Fatalf("expected error because of nil input config")
+		} else if err.Error() != "HeUniform config data validation failed: expected config not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = initializers.NewHeUniform(&initializers.HeUniformConfig{FanIn: 0})
+		if err == nil {
+			t.Fatalf("expected error because of non-positive 'FanIn'")
+		} else if err.Error() != "HeUniform config data validation failed: expected 'FanIn' to be positive: got (0)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = initializers.NewHeUniform(&initializers.HeUniformConfig{FanIn: -1})
+		if err == nil {
+			t.Fatalf("expected error because of non-positive 'FanIn'")
+		} else if err.Error() != "HeUniform config data validation failed: expected 'FanIn' to be positive: got (-1)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		/* ------------------------------ */
+
+	})
+}

--- a/component/initializers/initializers.go
+++ b/component/initializers/initializers.go
@@ -1,0 +1,10 @@
+package initializers
+
+import "github.com/sahandsafizadeh/qeep/tensor"
+
+func tensorInitConf() *tensor.Config {
+	return &tensor.Config{
+		Device:    tensor.CPU,
+		GradTrack: true,
+	}
+}

--- a/component/initializers/normal.go
+++ b/component/initializers/normal.go
@@ -1,0 +1,58 @@
+package initializers
+
+import (
+	"fmt"
+
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+type Normal struct {
+	mean   float64
+	stdDev float64
+}
+
+type NormalConfig struct {
+	Mean   float64
+	StdDev float64
+}
+
+const normalDefaultMean = 0.
+const normalDefaultStdDev = 0.05
+
+func NewNormal(conf *NormalConfig) (c *Normal, err error) {
+	conf, err = toValidNormalConfig(conf)
+	if err != nil {
+		err = fmt.Errorf("Normal config data validation failed: %w", err)
+		return
+	}
+
+	return &Normal{
+		mean:   conf.Mean,
+		stdDev: conf.StdDev,
+	}, nil
+}
+
+func (c *Normal) Init(shape []int) (x tensor.Tensor, err error) {
+	return tensor.RandN(shape, c.mean, c.stdDev, tensorInitConf())
+}
+
+/* ----- helpers ----- */
+
+func toValidNormalConfig(iconf *NormalConfig) (conf *NormalConfig, err error) {
+	if iconf == nil {
+		iconf = &NormalConfig{
+			Mean:   normalDefaultMean,
+			StdDev: normalDefaultStdDev,
+		}
+	}
+
+	conf = new(NormalConfig)
+	*conf = *iconf
+
+	if !(conf.StdDev > 0) {
+		err = fmt.Errorf("expected 'StdDev' to be positive: got (%f)", conf.StdDev)
+		return
+	}
+
+	return conf, nil
+}

--- a/component/initializers/normal_test.go
+++ b/component/initializers/normal_test.go
@@ -1,0 +1,66 @@
+package initializers_test
+
+import (
+	"testing"
+
+	"github.com/sahandsafizadeh/qeep/component/initializers"
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+func TestNormal(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(_ tensor.Device) {
+
+		initializer, err := initializers.NewNormal(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		/* ------------------------------ */
+
+		x, err := initializer.Init([]int{32, 32})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		shape := x.Shape()
+		if !shapesEqual(shape, []int{32, 32}) {
+			t.Fatalf("expected tensor to have shape [32, 32], got %v", shape)
+		}
+
+		err = tensor.BackPropagate(x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if x.Gradient() == nil {
+			t.Fatalf("expected gradient not to be nil")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+func TestValidationNormal(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(_ tensor.Device) {
+
+		/* ------------------------------ */
+
+		_, err := initializers.NewNormal(&initializers.NormalConfig{StdDev: 0.})
+		if err == nil {
+			t.Fatalf("expected error because of non-positive 'StdDev'")
+		} else if err.Error() != "Normal config data validation failed: expected 'StdDev' to be positive: got (0.000000)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = initializers.NewNormal(&initializers.NormalConfig{StdDev: -1.})
+		if err == nil {
+			t.Fatalf("expected error because of non-positive 'StdDev'")
+		} else if err.Error() != "Normal config data validation failed: expected 'StdDev' to be positive: got (-1.000000)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		/* ------------------------------ */
+
+	})
+}

--- a/component/initializers/uniform.go
+++ b/component/initializers/uniform.go
@@ -1,0 +1,58 @@
+package initializers
+
+import (
+	"fmt"
+
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+type Uniform struct {
+	lower float64
+	upper float64
+}
+
+type UniformConfig struct {
+	Lower float64
+	Upper float64
+}
+
+const uniformDefaultLower = -0.05
+const uniformDefaultUpper = 0.05
+
+func NewUniform(conf *UniformConfig) (c *Uniform, err error) {
+	conf, err = toValidUniformConfig(conf)
+	if err != nil {
+		err = fmt.Errorf("Uniform config data validation failed: %w", err)
+		return
+	}
+
+	return &Uniform{
+		lower: conf.Lower,
+		upper: conf.Upper,
+	}, nil
+}
+
+func (c *Uniform) Init(shape []int) (x tensor.Tensor, err error) {
+	return tensor.RandU(shape, c.lower, c.upper, tensorInitConf())
+}
+
+/* ----- helpers ----- */
+
+func toValidUniformConfig(iconf *UniformConfig) (conf *UniformConfig, err error) {
+	if iconf == nil {
+		iconf = &UniformConfig{
+			Lower: uniformDefaultLower,
+			Upper: uniformDefaultUpper,
+		}
+	}
+
+	conf = new(UniformConfig)
+	*conf = *iconf
+
+	if !(conf.Lower < conf.Upper) {
+		err = fmt.Errorf("expected 'Lower' to be less than 'Upper': (%f) >= (%f)", conf.Lower, conf.Upper)
+		return
+	}
+
+	return conf, nil
+}

--- a/component/initializers/uniform_test.go
+++ b/component/initializers/uniform_test.go
@@ -1,0 +1,72 @@
+package initializers_test
+
+import (
+	"testing"
+
+	"github.com/sahandsafizadeh/qeep/component/initializers"
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+func TestUniform(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(_ tensor.Device) {
+
+		initializer, err := initializers.NewUniform(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		/* ------------------------------ */
+
+		x, err := initializer.Init([]int{32, 32})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		shape := x.Shape()
+		if !shapesEqual(shape, []int{32, 32}) {
+			t.Fatalf("expected tensor to have shape [32, 32], got %v", shape)
+		}
+
+		err = tensor.BackPropagate(x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if x.Gradient() == nil {
+			t.Fatalf("expected gradient not to be nil")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+func TestValidationUniform(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(_ tensor.Device) {
+
+		/* ------------------------------ */
+
+		_, err := initializers.NewUniform(&initializers.UniformConfig{
+			Lower: 1.,
+			Upper: 1.,
+		})
+		if err == nil {
+			t.Fatalf("expected error because of 'Lower' not being less than 'Upper'")
+		} else if err.Error() != "Uniform config data validation failed: expected 'Lower' to be less than 'Upper': (1.000000) >= (1.000000)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = initializers.NewUniform(&initializers.UniformConfig{
+			Lower: 1.5,
+			Upper: 1.,
+		})
+		if err == nil {
+			t.Fatalf("expected error because of 'Lower' not being less than 'Upper'")
+		} else if err.Error() != "Uniform config data validation failed: expected 'Lower' to be less than 'Upper': (1.500000) >= (1.000000)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		/* ------------------------------ */
+
+	})
+}

--- a/component/initializers/xavier_normal.go
+++ b/component/initializers/xavier_normal.go
@@ -1,0 +1,60 @@
+package initializers
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+type XavierNormal struct {
+	fanIn  int
+	fanOut int
+}
+
+type XavierNormalConfig struct {
+	FanIn  int
+	FanOut int
+}
+
+func NewXavierNormal(conf *XavierNormalConfig) (c *XavierNormal, err error) {
+	conf, err = toValidXavierNormalConfig(conf)
+	if err != nil {
+		err = fmt.Errorf("XavierNormal config data validation failed: %w", err)
+		return
+	}
+
+	return &XavierNormal{
+		fanIn:  conf.FanIn,
+		fanOut: conf.FanOut,
+	}, nil
+}
+
+func (c *XavierNormal) Init(shape []int) (x tensor.Tensor, err error) {
+	s := math.Sqrt(2. / float64(c.fanIn+c.fanOut))
+	return tensor.RandN(shape, 0., s, tensorInitConf())
+}
+
+/* ----- helpers ----- */
+
+func toValidXavierNormalConfig(iconf *XavierNormalConfig) (conf *XavierNormalConfig, err error) {
+	if iconf == nil {
+		err = fmt.Errorf("expected config not to be nil")
+		return
+	}
+
+	conf = new(XavierNormalConfig)
+	*conf = *iconf
+
+	if conf.FanIn <= 0 {
+		err = fmt.Errorf("expected 'FanIn' to be positive: got (%d)", conf.FanIn)
+		return
+	}
+
+	if conf.FanOut <= 0 {
+		err = fmt.Errorf("expected 'FanOut' to be positive: got (%d)", conf.FanOut)
+		return
+	}
+
+	return conf, nil
+}

--- a/component/initializers/xavier_normal_test.go
+++ b/component/initializers/xavier_normal_test.go
@@ -1,0 +1,102 @@
+package initializers_test
+
+import (
+	"testing"
+
+	"github.com/sahandsafizadeh/qeep/component/initializers"
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+func TestXavierNormal(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(_ tensor.Device) {
+
+		initializer, err := initializers.NewXavierNormal(&initializers.XavierNormalConfig{
+			FanIn:  16,
+			FanOut: 4,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		/* ------------------------------ */
+
+		x, err := initializer.Init([]int{32, 32})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		shape := x.Shape()
+		if !shapesEqual(shape, []int{32, 32}) {
+			t.Fatalf("expected tensor to have shape [32, 32], got %v", shape)
+		}
+
+		err = tensor.BackPropagate(x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if x.Gradient() == nil {
+			t.Fatalf("expected gradient not to be nil")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+func TestValidationXavierNormal(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(_ tensor.Device) {
+
+		/* ------------------------------ */
+
+		_, err := initializers.NewXavierNormal(nil)
+		if err == nil {
+			t.Fatalf("expected error because of nil input config")
+		} else if err.Error() != "XavierNormal config data validation failed: expected config not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = initializers.NewXavierNormal(&initializers.XavierNormalConfig{
+			FanIn:  0,
+			FanOut: 1,
+		})
+		if err == nil {
+			t.Fatalf("expected error because of non-positive 'FanIn'")
+		} else if err.Error() != "XavierNormal config data validation failed: expected 'FanIn' to be positive: got (0)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = initializers.NewXavierNormal(&initializers.XavierNormalConfig{
+			FanIn:  -1,
+			FanOut: 1,
+		})
+		if err == nil {
+			t.Fatalf("expected error because of non-positive 'FanIn'")
+		} else if err.Error() != "XavierNormal config data validation failed: expected 'FanIn' to be positive: got (-1)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = initializers.NewXavierNormal(&initializers.XavierNormalConfig{
+			FanIn:  1,
+			FanOut: 0,
+		})
+		if err == nil {
+			t.Fatalf("expected error because of non-positive 'FanOut'")
+		} else if err.Error() != "XavierNormal config data validation failed: expected 'FanOut' to be positive: got (0)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = initializers.NewXavierNormal(&initializers.XavierNormalConfig{
+			FanIn:  1,
+			FanOut: -1,
+		})
+		if err == nil {
+			t.Fatalf("expected error because of non-positive 'FanOut'")
+		} else if err.Error() != "XavierNormal config data validation failed: expected 'FanOut' to be positive: got (-1)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		/* ------------------------------ */
+
+	})
+}

--- a/component/initializers/xavier_uniform.go
+++ b/component/initializers/xavier_uniform.go
@@ -1,0 +1,60 @@
+package initializers
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+type XavierUniform struct {
+	fanIn  int
+	fanOut int
+}
+
+type XavierUniformConfig struct {
+	FanIn  int
+	FanOut int
+}
+
+func NewXavierUniform(conf *XavierUniformConfig) (c *XavierUniform, err error) {
+	conf, err = toValidXavierUniformConfig(conf)
+	if err != nil {
+		err = fmt.Errorf("XavierUniform config data validation failed: %w", err)
+		return
+	}
+
+	return &XavierUniform{
+		fanIn:  conf.FanIn,
+		fanOut: conf.FanOut,
+	}, nil
+}
+
+func (c *XavierUniform) Init(shape []int) (x tensor.Tensor, err error) {
+	r := math.Sqrt(6. / float64(c.fanIn+c.fanOut))
+	return tensor.RandU(shape, -r, r, tensorInitConf())
+}
+
+/* ----- helpers ----- */
+
+func toValidXavierUniformConfig(iconf *XavierUniformConfig) (conf *XavierUniformConfig, err error) {
+	if iconf == nil {
+		err = fmt.Errorf("expected config not to be nil")
+		return
+	}
+
+	conf = new(XavierUniformConfig)
+	*conf = *iconf
+
+	if conf.FanIn <= 0 {
+		err = fmt.Errorf("expected 'FanIn' to be positive: got (%d)", conf.FanIn)
+		return
+	}
+
+	if conf.FanOut <= 0 {
+		err = fmt.Errorf("expected 'FanOut' to be positive: got (%d)", conf.FanOut)
+		return
+	}
+
+	return conf, nil
+}

--- a/component/initializers/xavier_uniform_test.go
+++ b/component/initializers/xavier_uniform_test.go
@@ -1,0 +1,102 @@
+package initializers_test
+
+import (
+	"testing"
+
+	"github.com/sahandsafizadeh/qeep/component/initializers"
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+func TestXavierUniform(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(_ tensor.Device) {
+
+		initializer, err := initializers.NewXavierUniform(&initializers.XavierUniformConfig{
+			FanIn:  16,
+			FanOut: 4,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		/* ------------------------------ */
+
+		x, err := initializer.Init([]int{32, 32})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		shape := x.Shape()
+		if !shapesEqual(shape, []int{32, 32}) {
+			t.Fatalf("expected tensor to have shape [32, 32], got %v", shape)
+		}
+
+		err = tensor.BackPropagate(x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if x.Gradient() == nil {
+			t.Fatalf("expected gradient not to be nil")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+func TestValidationXavierUniform(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(_ tensor.Device) {
+
+		/* ------------------------------ */
+
+		_, err := initializers.NewXavierUniform(nil)
+		if err == nil {
+			t.Fatalf("expected error because of nil input config")
+		} else if err.Error() != "XavierUniform config data validation failed: expected config not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = initializers.NewXavierUniform(&initializers.XavierUniformConfig{
+			FanIn:  0,
+			FanOut: 1,
+		})
+		if err == nil {
+			t.Fatalf("expected error because of non-positive 'FanIn'")
+		} else if err.Error() != "XavierUniform config data validation failed: expected 'FanIn' to be positive: got (0)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = initializers.NewXavierUniform(&initializers.XavierUniformConfig{
+			FanIn:  -1,
+			FanOut: 1,
+		})
+		if err == nil {
+			t.Fatalf("expected error because of non-positive 'FanIn'")
+		} else if err.Error() != "XavierUniform config data validation failed: expected 'FanIn' to be positive: got (-1)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = initializers.NewXavierUniform(&initializers.XavierUniformConfig{
+			FanIn:  1,
+			FanOut: 0,
+		})
+		if err == nil {
+			t.Fatalf("expected error because of non-positive 'FanOut'")
+		} else if err.Error() != "XavierUniform config data validation failed: expected 'FanOut' to be positive: got (0)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = initializers.NewXavierUniform(&initializers.XavierUniformConfig{
+			FanIn:  1,
+			FanOut: -1,
+		})
+		if err == nil {
+			t.Fatalf("expected error because of non-positive 'FanOut'")
+		} else if err.Error() != "XavierUniform config data validation failed: expected 'FanOut' to be positive: got (-1)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		/* ------------------------------ */
+
+	})
+}

--- a/component/layers/activations/leaky_relu.go
+++ b/component/layers/activations/leaky_relu.go
@@ -1,0 +1,84 @@
+package activations
+
+import (
+	"fmt"
+
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+type LeakyRelu struct {
+	m float64
+}
+
+type LeakyReluConfig struct {
+	M float64
+}
+
+const leakyReluDefaultM = 0.01
+
+func NewLeakyRelu(conf *LeakyReluConfig) (c *LeakyRelu) {
+	conf = toValidLeakyReluConfig(conf)
+
+	return &LeakyRelu{
+		m: conf.M,
+	}
+}
+
+func (c *LeakyRelu) Forward(xs ...tensor.Tensor) (y tensor.Tensor, err error) {
+	x, err := c.toValidInputs(xs)
+	if err != nil {
+		err = fmt.Errorf("LeakyRelu input data validation failed: %w", err)
+		return
+	}
+
+	return c.forward(x)
+}
+
+func (c *LeakyRelu) forward(x tensor.Tensor) (y tensor.Tensor, err error) {
+	_0 := x.Scale(0)
+
+	s1, err := _0.ElMax(x)
+	if err != nil {
+		return
+	}
+
+	s2, err := _0.ElMin(x)
+	if err != nil {
+		return
+	}
+
+	s2 = s2.Scale(c.m)
+
+	return s1.Add(s2)
+}
+
+/* ----- helpers ----- */
+
+func (c *LeakyRelu) toValidInputs(xs []tensor.Tensor) (x tensor.Tensor, err error) {
+	if len(xs) != 1 {
+		err = fmt.Errorf("expected exactly one input tensor: got (%d)", len(xs))
+		return
+	}
+
+	x = xs[0]
+
+	if x == nil {
+		err = fmt.Errorf("expected input tensor not to be nil")
+		return
+	}
+
+	return x, nil
+}
+
+func toValidLeakyReluConfig(iconf *LeakyReluConfig) (conf *LeakyReluConfig) {
+	if iconf == nil {
+		iconf = &LeakyReluConfig{
+			M: leakyReluDefaultM,
+		}
+	}
+
+	conf = new(LeakyReluConfig)
+	*conf = *iconf
+
+	return conf
+}

--- a/component/layers/activations/leaky_relu_test.go
+++ b/component/layers/activations/leaky_relu_test.go
@@ -1,0 +1,91 @@
+package activations_test
+
+import (
+	"testing"
+
+	"github.com/sahandsafizadeh/qeep/component/layers/activations"
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+func TestLeakyRelu(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{Device: dev}
+
+		activation := activations.NewLeakyRelu(&activations.LeakyReluConfig{M: 0.5})
+
+		/* ------------------------------ */
+
+		x, err := tensor.TensorOf([][]float64{
+			{-2., -1., -0.01},
+			{0., 0., 0.},
+			{0.01, 1., 2.},
+		}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err := activation.Forward(x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err := tensor.TensorOf([][]float64{
+			{-1., -0.5, -0.005},
+			{0., 0., 0.},
+			{0.01, 1., 2.},
+		}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+func TestValidationLeakyRelu(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{Device: dev}
+
+		activation := activations.NewLeakyRelu(nil)
+
+		/* ------------------------------ */
+
+		x, err := tensor.Zeros(nil, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = activation.Forward()
+		if err == nil {
+			t.Fatalf("expected error because of not receiving one input tensor")
+		} else if err.Error() != "LeakyRelu input data validation failed: expected exactly one input tensor: got (0)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = activation.Forward(x, x)
+		if err == nil {
+			t.Fatalf("expected error because of not receiving one input tensor")
+		} else if err.Error() != "LeakyRelu input data validation failed: expected exactly one input tensor: got (2)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = activation.Forward(nil)
+		if err == nil {
+			t.Fatalf("expected error because of nil input tensor")
+		} else if err.Error() != "LeakyRelu input data validation failed: expected input tensor not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		/* ------------------------------ */
+
+	})
+}

--- a/component/layers/activations/relu.go
+++ b/component/layers/activations/relu.go
@@ -1,0 +1,48 @@
+package activations
+
+import (
+	"fmt"
+
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+type Relu struct {
+}
+
+func NewRelu() (c *Relu) {
+	return &Relu{}
+}
+
+func (c *Relu) Forward(xs ...tensor.Tensor) (y tensor.Tensor, err error) {
+	x, err := c.toValidInputs(xs)
+	if err != nil {
+		err = fmt.Errorf("Relu input data validation failed: %w", err)
+		return
+	}
+
+	return c.forward(x)
+}
+
+func (c *Relu) forward(x tensor.Tensor) (y tensor.Tensor, err error) {
+	_0 := x.Scale(0)
+
+	return _0.ElMax(x)
+}
+
+/* ----- helpers ----- */
+
+func (c *Relu) toValidInputs(xs []tensor.Tensor) (x tensor.Tensor, err error) {
+	if len(xs) != 1 {
+		err = fmt.Errorf("expected exactly one input tensor: got (%d)", len(xs))
+		return
+	}
+
+	x = xs[0]
+
+	if x == nil {
+		err = fmt.Errorf("expected input tensor not to be nil")
+		return
+	}
+
+	return x, nil
+}

--- a/component/layers/activations/relu_test.go
+++ b/component/layers/activations/relu_test.go
@@ -1,0 +1,91 @@
+package activations_test
+
+import (
+	"testing"
+
+	"github.com/sahandsafizadeh/qeep/component/layers/activations"
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+func TestRelu(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{Device: dev}
+
+		activation := activations.NewRelu()
+
+		/* ------------------------------ */
+
+		x, err := tensor.TensorOf([][]float64{
+			{-2., -1., -0.01},
+			{0., 0., 0.},
+			{0.01, 1., 2.},
+		}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err := activation.Forward(x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err := tensor.TensorOf([][]float64{
+			{0., 0., 0.},
+			{0., 0., 0.},
+			{0.01, 1., 2.},
+		}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+func TestValidationRelu(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{Device: dev}
+
+		activation := activations.NewRelu()
+
+		/* ------------------------------ */
+
+		x, err := tensor.Zeros(nil, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = activation.Forward()
+		if err == nil {
+			t.Fatalf("expected error because of not receiving one input tensor")
+		} else if err.Error() != "Relu input data validation failed: expected exactly one input tensor: got (0)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = activation.Forward(x, x)
+		if err == nil {
+			t.Fatalf("expected error because of not receiving one input tensor")
+		} else if err.Error() != "Relu input data validation failed: expected exactly one input tensor: got (2)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = activation.Forward(nil)
+		if err == nil {
+			t.Fatalf("expected error because of nil input tensor")
+		} else if err.Error() != "Relu input data validation failed: expected input tensor not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		/* ------------------------------ */
+
+	})
+}

--- a/component/layers/activations/sigmoid.go
+++ b/component/layers/activations/sigmoid.go
@@ -1,0 +1,55 @@
+package activations
+
+import (
+	"fmt"
+
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+type Sigmoid struct {
+}
+
+func NewSigmoid() (c *Sigmoid) {
+	return &Sigmoid{}
+}
+
+func (c *Sigmoid) Forward(xs ...tensor.Tensor) (y tensor.Tensor, err error) {
+	x, err := c.toValidInputs(xs)
+	if err != nil {
+		err = fmt.Errorf("Sigmoid input data validation failed: %w", err)
+		return
+	}
+
+	return c.forward(x)
+}
+
+func (c *Sigmoid) forward(x tensor.Tensor) (y tensor.Tensor, err error) {
+	_1 := x.Pow(0)
+	x = x.Scale(-1)
+	x = x.Exp()
+
+	y, err = _1.Add(x)
+	if err != nil {
+		return
+	}
+
+	return y.Pow(-1), nil
+}
+
+/* ----- helpers ----- */
+
+func (c *Sigmoid) toValidInputs(xs []tensor.Tensor) (x tensor.Tensor, err error) {
+	if len(xs) != 1 {
+		err = fmt.Errorf("expected exactly one input tensor: got (%d)", len(xs))
+		return
+	}
+
+	x = xs[0]
+
+	if x == nil {
+		err = fmt.Errorf("expected input tensor not to be nil")
+		return
+	}
+
+	return x, nil
+}

--- a/component/layers/activations/sigmoid_test.go
+++ b/component/layers/activations/sigmoid_test.go
@@ -1,0 +1,143 @@
+package activations_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/sahandsafizadeh/qeep/component/layers/activations"
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+func TestSigmoid(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{Device: dev}
+
+		activation := activations.NewSigmoid()
+
+		/* ------------------------------ */
+
+		x, err := tensor.TensorOf(math.Inf(-1), conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err := activation.Forward(x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		val, err := act.At()
+		if err != nil {
+			t.Fatal(err)
+		} else if !(-1e-10 < val && val < 1e-10) {
+			t.Fatalf("expected scalar tensors value to be (0): got (%f)", val)
+		}
+
+		/* ------------------------------ */
+
+		x, err = tensor.TensorOf(math.Inf(+1), conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = activation.Forward(x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		val, err = act.At()
+		if err != nil {
+			t.Fatal(err)
+		} else if !(1.-1e-10 < val && val < 1.+1e-10) {
+			t.Fatalf("expected scalar tensors value to be (1): got (%f)", val)
+		}
+
+		/* ------------------------------ */
+
+		x, err = tensor.TensorOf(1., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = activation.Forward(x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		c := 1. / (1 + (1. / math.E))
+
+		val, err = act.At()
+		if err != nil {
+			t.Fatal(err)
+		} else if !(c-1e-10 < val && val < c+1e-10) {
+			t.Fatalf("expected scalar tensors value to be (1/(1+e^(-1))): got (%f)", val)
+		}
+
+		/* ------------------------------ */
+
+		x, err = tensor.Zeros([]int{2, 3}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = activation.Forward(x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err := tensor.Full([]int{2, 3}, 0.5, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+func TestValidationSigmoid(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{Device: dev}
+
+		activation := activations.NewSigmoid()
+
+		/* ------------------------------ */
+
+		x, err := tensor.Zeros(nil, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = activation.Forward()
+		if err == nil {
+			t.Fatalf("expected error because of not receiving one input tensor")
+		} else if err.Error() != "Sigmoid input data validation failed: expected exactly one input tensor: got (0)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = activation.Forward(x, x)
+		if err == nil {
+			t.Fatalf("expected error because of not receiving one input tensor")
+		} else if err.Error() != "Sigmoid input data validation failed: expected exactly one input tensor: got (2)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = activation.Forward(nil)
+		if err == nil {
+			t.Fatalf("expected error because of nil input tensor")
+		} else if err.Error() != "Sigmoid input data validation failed: expected input tensor not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		/* ------------------------------ */
+
+	})
+}

--- a/component/layers/activations/softmax.go
+++ b/component/layers/activations/softmax.go
@@ -1,0 +1,93 @@
+package activations
+
+import (
+	"fmt"
+
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+type Softmax struct {
+	dim int
+}
+
+type SoftmaxConfig struct {
+	Dim int
+}
+
+const softmaxDefaultDim = 0
+
+func NewSoftmax(conf *SoftmaxConfig) (c *Softmax, err error) {
+	conf, err = toValidSoftmaxConfig(conf)
+	if err != nil {
+		err = fmt.Errorf("Softmax config data validation failed: %w", err)
+		return
+	}
+
+	return &Softmax{
+		dim: conf.Dim,
+	}, nil
+}
+
+func (c *Softmax) Forward(xs ...tensor.Tensor) (y tensor.Tensor, err error) {
+	x, err := c.toValidInputs(xs)
+	if err != nil {
+		err = fmt.Errorf("Softmax input data validation failed: %w", err)
+		return
+	}
+
+	return c.forward(x)
+}
+
+func (c *Softmax) forward(x tensor.Tensor) (y tensor.Tensor, err error) {
+	x = x.Exp()
+
+	s, err := x.SumAlong(c.dim)
+	if err != nil {
+		return
+	}
+
+	return x.Div(s)
+}
+
+/* ----- helpers ----- */
+
+func (c *Softmax) toValidInputs(xs []tensor.Tensor) (x tensor.Tensor, err error) {
+	if len(xs) != 1 {
+		err = fmt.Errorf("expected exactly one input tensor: got (%d)", len(xs))
+		return
+	}
+
+	x = xs[0]
+
+	if x == nil {
+		err = fmt.Errorf("expected input tensor not to be nil")
+		return
+	}
+
+	shape := x.Shape()
+
+	if len(shape) <= c.dim {
+		err = fmt.Errorf("expected input tensor shape to match 'Dim': %v !~ (%d)", shape, c.dim)
+		return
+	}
+
+	return x, nil
+}
+
+func toValidSoftmaxConfig(iconf *SoftmaxConfig) (conf *SoftmaxConfig, err error) {
+	if iconf == nil {
+		iconf = &SoftmaxConfig{
+			Dim: softmaxDefaultDim,
+		}
+	}
+
+	conf = new(SoftmaxConfig)
+	*conf = *iconf
+
+	if conf.Dim < 0 {
+		err = fmt.Errorf("expected 'Dim' not to be negative: got (%d)", conf.Dim)
+		return
+	}
+
+	return conf, nil
+}

--- a/component/layers/activations/softmax_test.go
+++ b/component/layers/activations/softmax_test.go
@@ -1,0 +1,149 @@
+package activations_test
+
+import (
+	"testing"
+
+	"github.com/sahandsafizadeh/qeep/component/layers/activations"
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+func TestSoftmax(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{Device: dev}
+
+		activation, err := activations.NewSoftmax(&activations.SoftmaxConfig{Dim: 0})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		/* ------------------------------ */
+
+		x, err := tensor.Full([]int{4}, 0., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err := activation.Forward(x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err := tensor.Full([]int{4}, 0.25, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+		x, err = tensor.Full([]int{2, 3}, -10., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = activation.Forward(x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err = tensor.Full([]int{2, 3}, 0.5, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+		x, err = tensor.Full([]int{8, 6, 4}, 15., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = activation.Forward(x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err = tensor.Full([]int{8, 6, 4}, 0.125, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+func TestValidationSoftmax(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{Device: dev}
+
+		activation, err := activations.NewSoftmax(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		/* ------------------------------ */
+
+		x, err := tensor.Zeros(nil, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = activations.NewSoftmax(&activations.SoftmaxConfig{Dim: -1})
+		if err == nil {
+			t.Fatalf("expected error because of negative 'Dim'")
+		} else if err.Error() != "Softmax config data validation failed: expected 'Dim' not to be negative: got (-1)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = activation.Forward()
+		if err == nil {
+			t.Fatalf("expected error because of not receiving one input tensor")
+		} else if err.Error() != "Softmax input data validation failed: expected exactly one input tensor: got (0)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = activation.Forward(x, x)
+		if err == nil {
+			t.Fatalf("expected error because of not receiving one input tensor")
+		} else if err.Error() != "Softmax input data validation failed: expected exactly one input tensor: got (2)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = activation.Forward(nil)
+		if err == nil {
+			t.Fatalf("expected error because of nil input tensor")
+		} else if err.Error() != "Softmax input data validation failed: expected input tensor not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = activation.Forward(x)
+		if err == nil {
+			t.Fatalf("expected error because of input tensors shape not matching softmax 'Dim'")
+		} else if err.Error() != "Softmax input data validation failed: expected input tensor shape to match 'Dim': [] !~ (0)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		/* ------------------------------ */
+
+	})
+}

--- a/component/layers/activations/tanh.go
+++ b/component/layers/activations/tanh.go
@@ -1,0 +1,46 @@
+package activations
+
+import (
+	"fmt"
+
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+type Tanh struct {
+}
+
+func NewTanh() (c *Tanh) {
+	return &Tanh{}
+}
+
+func (c *Tanh) Forward(xs ...tensor.Tensor) (y tensor.Tensor, err error) {
+	x, err := c.toValidInputs(xs)
+	if err != nil {
+		err = fmt.Errorf("Tanh input data validation failed: %w", err)
+		return
+	}
+
+	return c.forward(x)
+}
+
+func (c *Tanh) forward(x tensor.Tensor) (y tensor.Tensor, err error) {
+	return x.Tanh(), nil
+}
+
+/* ----- helpers ----- */
+
+func (c *Tanh) toValidInputs(xs []tensor.Tensor) (x tensor.Tensor, err error) {
+	if len(xs) != 1 {
+		err = fmt.Errorf("expected exactly one input tensor: got (%d)", len(xs))
+		return
+	}
+
+	x = xs[0]
+
+	if x == nil {
+		err = fmt.Errorf("expected input tensor not to be nil")
+		return
+	}
+
+	return x, nil
+}

--- a/component/layers/activations/tanh_test.go
+++ b/component/layers/activations/tanh_test.go
@@ -1,0 +1,82 @@
+package activations_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/sahandsafizadeh/qeep/component/layers/activations"
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+func TestTanh(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{Device: dev}
+
+		activation := activations.NewTanh()
+
+		/* ------------------------------ */
+
+		x, err := tensor.TensorOf(1., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err := activation.Forward(x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		c := (math.E*math.E - 1) / (math.E*math.E + 1)
+
+		val, err := act.At()
+		if err != nil {
+			t.Fatal(err)
+		} else if !(c-1e-10 < val && val < c+1e-10) {
+			t.Fatalf("expected scalar tensors value to be ((e^2-1)/(e^2+1)): got (%f)", val)
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+func TestValidationTanh(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{Device: dev}
+
+		activation := activations.NewTanh()
+
+		/* ------------------------------ */
+
+		x, err := tensor.Zeros(nil, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = activation.Forward()
+		if err == nil {
+			t.Fatalf("expected error because of not receiving one input tensor")
+		} else if err.Error() != "Tanh input data validation failed: expected exactly one input tensor: got (0)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = activation.Forward(x, x)
+		if err == nil {
+			t.Fatalf("expected error because of not receiving one input tensor")
+		} else if err.Error() != "Tanh input data validation failed: expected exactly one input tensor: got (2)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = activation.Forward(nil)
+		if err == nil {
+			t.Fatalf("expected error because of nil input tensor")
+		} else if err.Error() != "Tanh input data validation failed: expected input tensor not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		/* ------------------------------ */
+
+	})
+}

--- a/component/layers/fc.go
+++ b/component/layers/fc.go
@@ -1,0 +1,217 @@
+package layers
+
+import (
+	"fmt"
+
+	"github.com/sahandsafizadeh/qeep/component/initializers"
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+type FC struct {
+	Weight tensor.Tensor
+	Bias   tensor.Tensor
+}
+
+type FCConfig struct {
+	Inputs       int
+	Outputs      int
+	Initializers map[string]Initializer
+}
+
+const (
+	fcWeightKey = "Weight"
+	fcBiasKey   = "Bias"
+)
+
+func NewFC(conf *FCConfig) (c *FC, err error) {
+	conf, err = toValidFCConfig(conf)
+	if err != nil {
+		err = fmt.Errorf("FC config data validation failed: %w", err)
+		return
+	}
+
+	var (
+		win = conf.Initializers[fcWeightKey]
+		bin = conf.Initializers[fcBiasKey]
+	)
+
+	w, err := win.Init([]int{conf.Outputs})
+	if err != nil {
+		return
+	}
+
+	b, err := bin.Init([]int{conf.Outputs})
+	if err != nil {
+		return
+	}
+
+	err = validateInitializedWeights(w, b, conf)
+	if err != nil {
+		err = fmt.Errorf("FC initialized weight validation failed: %w", err)
+		return
+	}
+
+	return &FC{
+		Weight: w,
+		Bias:   b,
+	}, nil
+}
+
+func (c *FC) Weights() []Weight {
+	return []Weight{
+		{
+			Value:     &c.Weight,
+			Trainable: true,
+		},
+		{
+			Value:     &c.Bias,
+			Trainable: true,
+		},
+	}
+}
+
+func (c *FC) Forward(xs ...tensor.Tensor) (y tensor.Tensor, err error) {
+	x, err := c.toValidInputs(xs)
+	if err != nil {
+		err = fmt.Errorf("FC input data validation failed: %w", err)
+		return
+	}
+
+	return c.forward(x)
+}
+
+func (c *FC) forward(x tensor.Tensor) (y tensor.Tensor, err error) {
+	w, err := c.Weight.UnSqueeze(1)
+	if err != nil {
+		return
+	}
+
+	b := c.Bias
+
+	x, err = x.UnSqueeze(1) // last dim - 1
+	if err != nil {
+		return
+	}
+
+	y, err = w.MatMul(x)
+	if err != nil {
+		return
+	}
+
+	y, err = y.SumAlong(2) // last dim
+	if err != nil {
+		return
+	}
+
+	y, err = y.Add(b)
+	if err != nil {
+		return
+	}
+
+	return y, nil
+}
+
+/* ----- helpers ----- */
+
+func (c *FC) toValidInputs(xs []tensor.Tensor) (x tensor.Tensor, err error) {
+	if len(xs) != 1 {
+		err = fmt.Errorf("expected exactly one input tensor: got (%d)", len(xs))
+		return
+	}
+
+	x = xs[0]
+
+	if x == nil {
+		err = fmt.Errorf("expected input tensor not to be nil")
+		return
+	}
+
+	shape := x.Shape()
+
+	if len(shape) != 2 {
+		err = fmt.Errorf("expected input tensor to have exactly two dimensions (batch, data): got (%d)", len(shape))
+		return
+	}
+
+	return x, nil
+}
+
+func toValidFCConfig(iconf *FCConfig) (conf *FCConfig, err error) {
+	if iconf == nil {
+		err = fmt.Errorf("expected config not to be nil")
+		return
+	}
+
+	conf = new(FCConfig)
+	*conf = *iconf
+
+	if conf.Inputs <= 0 {
+		err = fmt.Errorf("expected 'Inputs' to be positive: got (%d)", conf.Inputs)
+		return
+	}
+
+	if conf.Outputs <= 0 {
+		err = fmt.Errorf("expected 'Outputs' to be positive: got (%d)", conf.Outputs)
+		return
+	}
+
+	if conf.Initializers == nil {
+		conf.Initializers = make(map[string]Initializer)
+	}
+
+	if initializer, ok := conf.Initializers[fcWeightKey]; !ok {
+		conf.Initializers[fcWeightKey], err = initializers.NewXavierUniform(
+			&initializers.XavierUniformConfig{
+				FanIn:  conf.Inputs,
+				FanOut: conf.Outputs,
+			})
+		if err != nil {
+			return
+		}
+	} else if initializer == nil {
+		err = fmt.Errorf("expected 'Weight' initializer not to be nil")
+		return
+	}
+
+	if initializer, ok := conf.Initializers[fcBiasKey]; !ok {
+		conf.Initializers[fcBiasKey] = initializers.NewFull(
+			&initializers.FullConfig{
+				Value: 0.,
+			})
+		if err != nil {
+			return
+		}
+	} else if initializer == nil {
+		err = fmt.Errorf("expected 'Bias' initializer not to be nil")
+		return
+	}
+
+	return conf, nil
+}
+
+func validateInitializedWeights(w tensor.Tensor, b tensor.Tensor, conf *FCConfig) (err error) {
+	if w == nil || b == nil {
+		err = fmt.Errorf("expected initialized weights not to be nil")
+		return
+	}
+
+	shapew := w.Shape()
+	shapeb := b.Shape()
+
+	if len(shapew) != 1 || len(shapeb) != 1 {
+		err = fmt.Errorf("expected initialized weights to have exactly one dimension")
+		return
+	}
+
+	if shapew[0] != conf.Outputs {
+		err = fmt.Errorf("expected initialized 'Weight' size to match 'Outputs': (%d) != (%d)", shapew[0], conf.Outputs)
+		return
+	}
+
+	if shapeb[0] != conf.Outputs {
+		err = fmt.Errorf("expected initialized 'Bias' size to match 'Outputs': (%d) != (%d)", shapeb[0], conf.Outputs)
+		return
+	}
+
+	return nil
+}

--- a/component/layers/fc_test.go
+++ b/component/layers/fc_test.go
@@ -1,0 +1,466 @@
+package layers_test
+
+import (
+	"testing"
+
+	"github.com/sahandsafizadeh/qeep/component/initializers"
+	"github.com/sahandsafizadeh/qeep/component/layers"
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+func TestFC(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{Device: dev}
+
+		/* ------------------------------ */
+
+		layer, err := layers.NewFC(&layers.FCConfig{
+			Inputs:  1,
+			Outputs: 1,
+			Initializers: map[string]layers.Initializer{
+				"Weight": initializers.NewFull(&initializers.FullConfig{Value: 3.}),
+				"Bias":   initializers.NewFull(&initializers.FullConfig{Value: 1.}),
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		x, err := tensor.TensorOf([][]float64{{-1.}}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err := layer.Forward(x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err := tensor.TensorOf([][]float64{{-2.}}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+		layer, err = layers.NewFC(&layers.FCConfig{
+			Inputs:  4,
+			Outputs: 1,
+			Initializers: map[string]layers.Initializer{
+				"Weight": initializers.NewFull(&initializers.FullConfig{Value: -2.}),
+				"Bias":   initializers.NewFull(&initializers.FullConfig{Value: 3.}),
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		x, err = tensor.TensorOf([][]float64{{-2., 0., 1., 2.}}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = layer.Forward(x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err = tensor.TensorOf([][]float64{{1.}}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+		layer, err = layers.NewFC(&layers.FCConfig{
+			Inputs:  5,
+			Outputs: 2,
+			Initializers: map[string]layers.Initializer{
+				"Weight": initializers.NewFull(&initializers.FullConfig{Value: 5.}),
+				"Bias":   initializers.NewFull(&initializers.FullConfig{Value: -1.}),
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		x, err = tensor.TensorOf([][]float64{{-3., -2., 1., 1., 5.}}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = layer.Forward(x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err = tensor.TensorOf([][]float64{{9., 9.}}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+		layer, err = layers.NewFC(&layers.FCConfig{
+			Inputs:  8,
+			Outputs: 3,
+			Initializers: map[string]layers.Initializer{
+				"Weight": initializers.NewFull(&initializers.FullConfig{Value: 2.}),
+				"Bias":   initializers.NewFull(&initializers.FullConfig{Value: 1.}),
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		x, err = tensor.TensorOf([][]float64{
+			{0., 1., 2., 3., 4., 5., 6., 7.},
+			{1., 2., 3., 4., 5., 6., 7., 8.},
+			{2., 3., 4., 5., 6., 7., 8., 9.},
+			{3., 4., 5., 6., 7., 8., 9., 0.},
+		}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = layer.Forward(x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err = tensor.TensorOf([][]float64{
+			{57., 57., 57.},
+			{73., 73., 73.},
+			{89., 89., 89.},
+			{85., 85., 85.},
+		}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+		weights := layer.Weights()
+		if len(weights) != 2 {
+			t.Fatalf("expected FC to have (2) trainable weights: got (%d)", len(weights))
+		}
+
+		expw := layers.Weight{
+			Value:     &layer.Weight,
+			Trainable: true,
+		}
+		if weights[0] != expw {
+			t.Fatal("expected FC weight (0) to be trainable and point to 'Weight'")
+		}
+
+		expb := layers.Weight{
+			Value:     &layer.Bias,
+			Trainable: true,
+		}
+		if weights[1] != expb {
+			t.Fatal("expected FC weight (1) to be trainable and point to 'Bias'")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+func TestValidationFC(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{Device: dev}
+
+		/* ------------------------------ */
+
+		_, err := layers.NewFC(nil)
+		if err == nil {
+			t.Fatalf("expected error because of nil input config")
+		} else if err.Error() != "FC config data validation failed: expected config not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = layers.NewFC(&layers.FCConfig{
+			Inputs:  0,
+			Outputs: 1,
+		})
+		if err == nil {
+			t.Fatalf("expected error because of non-positive 'Inputs'")
+		} else if err.Error() != "FC config data validation failed: expected 'Inputs' to be positive: got (0)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = layers.NewFC(&layers.FCConfig{
+			Inputs:  -1,
+			Outputs: 1,
+		})
+		if err == nil {
+			t.Fatalf("expected error because of non-positive 'Inputs'")
+		} else if err.Error() != "FC config data validation failed: expected 'Inputs' to be positive: got (-1)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = layers.NewFC(&layers.FCConfig{
+			Inputs:  1,
+			Outputs: 0,
+		})
+		if err == nil {
+			t.Fatalf("expected error because of non-positive 'Outputs'")
+		} else if err.Error() != "FC config data validation failed: expected 'Outputs' to be positive: got (0)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = layers.NewFC(&layers.FCConfig{
+			Inputs:  1,
+			Outputs: -1,
+		})
+		if err == nil {
+			t.Fatalf("expected error because of non-positive 'Outputs'")
+		} else if err.Error() != "FC config data validation failed: expected 'Outputs' to be positive: got (-1)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = layers.NewFC(&layers.FCConfig{
+			Inputs:  1,
+			Outputs: 1,
+			Initializers: map[string]layers.Initializer{
+				"Weight": nil,
+			},
+		})
+		if err == nil {
+			t.Fatalf("expected error because of nil 'Weight' initializer")
+		} else if err.Error() != "FC config data validation failed: expected 'Weight' initializer not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = layers.NewFC(&layers.FCConfig{
+			Inputs:  1,
+			Outputs: 1,
+			Initializers: map[string]layers.Initializer{
+				"Bias": nil,
+			},
+		})
+		if err == nil {
+			t.Fatalf("expected error because of nil 'Bias' initializer")
+		} else if err.Error() != "FC config data validation failed: expected 'Bias' initializer not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		/* ------------------------------ */
+
+		_, err = layers.NewFC(&layers.FCConfig{
+			Inputs:  1,
+			Outputs: 1,
+			Initializers: map[string]layers.Initializer{
+				"Weight": new(nilInitializer),
+			},
+		})
+		if err == nil {
+			t.Fatalf("expected error because of weights initialized with nil")
+		} else if err.Error() != "FC initialized weight validation failed: expected initialized weights not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = layers.NewFC(&layers.FCConfig{
+			Inputs:  1,
+			Outputs: 1,
+			Initializers: map[string]layers.Initializer{
+				"Bias": new(nilInitializer),
+			},
+		})
+		if err == nil {
+			t.Fatalf("expected error because of weights initialized with nil")
+		} else if err.Error() != "FC initialized weight validation failed: expected initialized weights not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = layers.NewFC(&layers.FCConfig{
+			Inputs:  1,
+			Outputs: 1,
+			Initializers: map[string]layers.Initializer{
+				"Weight": new(zeroDInitializer),
+			},
+		})
+		if err == nil {
+			t.Fatalf("expected error because of weights initialized with more/less than one dimension")
+		} else if err.Error() != "FC initialized weight validation failed: expected initialized weights to have exactly one dimension" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = layers.NewFC(&layers.FCConfig{
+			Inputs:  1,
+			Outputs: 1,
+			Initializers: map[string]layers.Initializer{
+				"Bias": new(zeroDInitializer),
+			},
+		})
+		if err == nil {
+			t.Fatalf("expected error because of weights initialized with more/less than one dimension")
+		} else if err.Error() != "FC initialized weight validation failed: expected initialized weights to have exactly one dimension" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = layers.NewFC(&layers.FCConfig{
+			Inputs:  1,
+			Outputs: 1,
+			Initializers: map[string]layers.Initializer{
+				"Weight": new(twoDInitializer),
+			},
+		})
+		if err == nil {
+			t.Fatalf("expected error because of weights initialized with more/less than one dimension")
+		} else if err.Error() != "FC initialized weight validation failed: expected initialized weights to have exactly one dimension" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = layers.NewFC(&layers.FCConfig{
+			Inputs:  1,
+			Outputs: 1,
+			Initializers: map[string]layers.Initializer{
+				"Bias": new(twoDInitializer),
+			},
+		})
+		if err == nil {
+			t.Fatalf("expected error because of weights initialized with more/less than one dimension")
+		} else if err.Error() != "FC initialized weight validation failed: expected initialized weights to have exactly one dimension" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = layers.NewFC(&layers.FCConfig{
+			Inputs:  1,
+			Outputs: 1,
+			Initializers: map[string]layers.Initializer{
+				"Weight": new(wrong1DInitializer),
+			},
+		})
+		if err == nil {
+			t.Fatalf("expected error because of 'Weight' being initialized with mismatched size")
+		} else if err.Error() != "FC initialized weight validation failed: expected initialized 'Weight' size to match 'Outputs': (2) != (1)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = layers.NewFC(&layers.FCConfig{
+			Inputs:  1,
+			Outputs: 1,
+			Initializers: map[string]layers.Initializer{
+				"Bias": new(wrong1DInitializer),
+			},
+		})
+		if err == nil {
+			t.Fatalf("expected error because of 'Bias' being initialized with mismatched size")
+		} else if err.Error() != "FC initialized weight validation failed: expected initialized 'Bias' size to match 'Outputs': (2) != (1)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		/* ------------------------------ */
+
+		layer, err := layers.NewFC(&layers.FCConfig{
+			Inputs:  1,
+			Outputs: 1,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		x1, err := tensor.Zeros([]int{1}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		x2, err := tensor.Zeros([]int{1, 1}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		x3, err := tensor.Zeros([]int{1, 1, 1}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = layer.Forward()
+		if err == nil {
+			t.Fatalf("expected error because of not receiving one input tensor")
+		} else if err.Error() != "FC input data validation failed: expected exactly one input tensor: got (0)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = layer.Forward(x2, x2)
+		if err == nil {
+			t.Fatalf("expected error because of not receiving one input tensor")
+		} else if err.Error() != "FC input data validation failed: expected exactly one input tensor: got (2)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = layer.Forward(nil)
+		if err == nil {
+			t.Fatalf("expected error because of nil input tensor")
+		} else if err.Error() != "FC input data validation failed: expected input tensor not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = layer.Forward(x1)
+		if err == nil {
+			t.Fatalf("expected error because of tensor having more/less than two dimensions")
+		} else if err.Error() != "FC input data validation failed: expected input tensor to have exactly two dimensions (batch, data): got (1)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = layer.Forward(x3)
+		if err == nil {
+			t.Fatalf("expected error because of tensor having more/less than two dimensions")
+		} else if err.Error() != "FC input data validation failed: expected input tensor to have exactly two dimensions (batch, data): got (3)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+/* ----- helpers ----- */
+
+type nilInitializer struct{}
+type zeroDInitializer struct{}
+type twoDInitializer struct{}
+type wrong1DInitializer struct{}
+
+func (c *nilInitializer) Init(shape []int) (x tensor.Tensor, err error) {
+	return nil, nil
+}
+
+func (c *zeroDInitializer) Init(shape []int) (x tensor.Tensor, err error) {
+	return tensor.Zeros(nil, nil)
+}
+
+func (c *twoDInitializer) Init(shape []int) (x tensor.Tensor, err error) {
+	return tensor.Zeros([]int{1, 1}, nil)
+}
+
+func (c *wrong1DInitializer) Init(shape []int) (x tensor.Tensor, err error) {
+	return tensor.Zeros([]int{shape[0] + 1}, nil)
+}

--- a/component/layers/input.go
+++ b/component/layers/input.go
@@ -1,0 +1,36 @@
+package layers
+
+import (
+	"fmt"
+
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+type Input struct {
+	SeedFunc func() tensor.Tensor
+}
+
+func NewInput() (c *Input) {
+	return &Input{}
+}
+
+func (c *Input) Forward(xs ...tensor.Tensor) (y tensor.Tensor, err error) {
+	err = c.validateInputs(xs)
+	if err != nil {
+		err = fmt.Errorf("Input input data validation failed: %w", err)
+		return
+	}
+
+	return c.SeedFunc(), nil
+}
+
+/* ----- helpers ----- */
+
+func (c *Input) validateInputs(xs []tensor.Tensor) (err error) {
+	if len(xs) != 0 {
+		err = fmt.Errorf("expected no input tensors: got (%d)", len(xs))
+		return
+	}
+
+	return nil
+}

--- a/component/layers/input_test.go
+++ b/component/layers/input_test.go
@@ -1,0 +1,92 @@
+package layers_test
+
+import (
+	"testing"
+
+	"github.com/sahandsafizadeh/qeep/component/layers"
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+func TestInput(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{Device: dev}
+
+		activation := layers.NewInput()
+
+		/* ------------------------------ */
+
+		activation.SeedFunc = func() tensor.Tensor { return nil }
+
+		act, err := activation.Forward()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if act != nil {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+		x, err := tensor.TensorOf([]float64{0., 1., 2., 3., 4., 5.}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		activation.SeedFunc = func() tensor.Tensor { return x }
+
+		act, err = activation.Forward()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err := tensor.TensorOf([]float64{0., 1., 2., 3., 4., 5.}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+func TestValidationInput(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{Device: dev}
+
+		activation := layers.NewInput()
+		activation.SeedFunc = func() tensor.Tensor { return nil }
+
+		/* ------------------------------ */
+
+		x, err := tensor.Zeros(nil, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = activation.Forward(x)
+		if err == nil {
+			t.Fatalf("expected error because of receiving input tensors")
+		} else if err.Error() != "Input input data validation failed: expected no input tensors: got (1)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = activation.Forward(x, x)
+		if err == nil {
+			t.Fatalf("expected error because of receiving input tensors")
+		} else if err.Error() != "Input input data validation failed: expected no input tensors: got (2)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		/* ------------------------------ */
+
+	})
+}

--- a/component/layers/types.go
+++ b/component/layers/types.go
@@ -1,0 +1,12 @@
+package layers
+
+import "github.com/sahandsafizadeh/qeep/tensor"
+
+type Initializer interface {
+	Init(shape []int) (tensor.Tensor, error)
+}
+
+type Weight struct {
+	Value     *tensor.Tensor
+	Trainable bool
+}

--- a/component/losses/bce.go
+++ b/component/losses/bce.go
@@ -1,0 +1,98 @@
+package losses
+
+import (
+	"fmt"
+
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+type BCE struct {
+}
+
+func NewBCE() (c *BCE) {
+	return new(BCE)
+}
+
+func (c *BCE) Compute(yp tensor.Tensor, yt tensor.Tensor) (l tensor.Tensor, err error) {
+	err = c.validateInputs(yp, yt)
+	if err != nil {
+		err = fmt.Errorf("BCE input data validation failed: %w", err)
+		return
+	}
+
+	/* ----- clip tensors ----- */
+
+	yt, err = clip(yt, 0, 1)
+	if err != nil {
+		return
+	}
+
+	yp, err = clip(yp, epsilon, 1-epsilon)
+	if err != nil {
+		return
+	}
+
+	/* ----- left sentence ----- */
+
+	t1 := yt
+	y1 := yp
+
+	s1, err := t1.Mul(y1.Log())
+	if err != nil {
+		return
+	}
+
+	/* ----- right sentence ----- */
+
+	_1 := yp.Pow(0)
+
+	t2, err := _1.Sub(yt)
+	if err != nil {
+		return
+	}
+
+	y2, err := _1.Sub(yp)
+	if err != nil {
+		return
+	}
+
+	s2, err := t2.Mul(y2.Log())
+	if err != nil {
+		return
+	}
+
+	/* ----- aggregation ----- */
+
+	l, err = s1.Add(s2)
+	if err != nil {
+		return
+	}
+
+	l = l.Scale(-1.)
+
+	return l.MeanAlong(0)
+}
+
+/* ----- helpers ----- */
+
+func (c *BCE) validateInputs(yp tensor.Tensor, yt tensor.Tensor) (err error) {
+	if yp == nil || yt == nil {
+		err = fmt.Errorf("expected input tensors not to be nil")
+		return
+	}
+
+	shapep := yp.Shape()
+	shapet := yt.Shape()
+
+	if len(shapep) != 1 || len(shapet) != 1 {
+		err = fmt.Errorf("expected input tensors to have exactly one dimension (batch)")
+		return
+	}
+
+	if shapep[0] != shapet[0] {
+		err = fmt.Errorf("expected input tensor sizes to match along batch dimension: (%d) != (%d)", shapep[0], shapet[0])
+		return
+	}
+
+	return nil
+}

--- a/component/losses/bce_test.go
+++ b/component/losses/bce_test.go
@@ -1,0 +1,233 @@
+package losses_test
+
+import (
+	"testing"
+
+	"github.com/sahandsafizadeh/qeep/component/losses"
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+func TestBCE(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{Device: dev}
+
+		loss := losses.NewBCE()
+
+		/* ------------------------------ */
+
+		yp, err := tensor.TensorOf([]float64{0.}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		yt, err := tensor.TensorOf([]float64{0.}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err := loss.Compute(yp, yt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		val, err := act.At()
+		if err != nil {
+			t.Fatal(err)
+		} else if !(0.-1e-10 < val && val < 0.+1e-10) {
+			t.Fatalf("expected scalar tensors value to be (0): got (%f)", val)
+		}
+
+		/* ------------------------------ */
+
+		yp, err = tensor.TensorOf([]float64{1.}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		yt, err = tensor.TensorOf([]float64{1.}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = loss.Compute(yp, yt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		val, err = act.At()
+		if err != nil {
+			t.Fatal(err)
+		} else if !(0.-1e-10 < val && val < 0.+1e-10) {
+			t.Fatalf("expected scalar tensors value to be (0): got (%f)", val)
+		}
+
+		/* ------------------------------ */
+
+		yp, err = tensor.TensorOf([]float64{0.}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		yt, err = tensor.TensorOf([]float64{2.}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = loss.Compute(yp, yt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		val, err = act.At()
+		if err != nil {
+			t.Fatal(err)
+		} else if !(27.630 < val && val < 27.632) {
+			t.Fatalf("expected scalar tensors value to be (27.632): got (%f)", val)
+		}
+
+		/* ------------------------------ */
+
+		yp, err = tensor.TensorOf([]float64{1.5}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		yt, err = tensor.TensorOf([]float64{-1.}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = loss.Compute(yp, yt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		val, err = act.At()
+		if err != nil {
+			t.Fatal(err)
+		} else if !(27.630 < val && val < 27.632) {
+			t.Fatalf("expected scalar tensors value to be (27.632): got (%f)", val)
+		}
+
+		/* ------------------------------ */
+
+		yp, err = tensor.TensorOf([]float64{0.1, 0.2, 0.8, 0.9}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		yt, err = tensor.TensorOf([]float64{0., 0., 1., 1.}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = loss.Compute(yp, yt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		val, err = act.At()
+		if err != nil {
+			t.Fatal(err)
+		} else if !(0.163 < val && val < 0.165) {
+			t.Fatalf("expected scalar tensors value to be (0.164): got (%f)", val)
+		}
+
+		/* ------------------------------ */
+
+		yp, err = tensor.TensorOf([]float64{0.9, 0.8, 0.2, 0.1}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		yt, err = tensor.TensorOf([]float64{0., 0., 1., 1.}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = loss.Compute(yp, yt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		val, err = act.At()
+		if err != nil {
+			t.Fatal(err)
+		} else if !(1.955 < val && val < 1.957) {
+			t.Fatalf("expected scalar tensors value to be (1.956): got (%f)", val)
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+func TestValidationBCE(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{Device: dev}
+
+		loss := losses.NewBCE()
+
+		/* ------------------------------ */
+
+		y1, err := tensor.Zeros([]int{}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		y2, err := tensor.Zeros([]int{1}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		y3, err := tensor.Zeros([]int{2}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		y4, err := tensor.Zeros([]int{1, 1}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = loss.Compute(nil, y1)
+		if err == nil {
+			t.Fatalf("expected error because of nil input tensor")
+		} else if err.Error() != "BCE input data validation failed: expected input tensors not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = loss.Compute(y1, nil)
+		if err == nil {
+			t.Fatalf("expected error because of nil input tensor")
+		} else if err.Error() != "BCE input data validation failed: expected input tensors not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = loss.Compute(y1, y2)
+		if err == nil {
+			t.Fatalf("expected error because of tensors having more/less than one dimension")
+		} else if err.Error() != "BCE input data validation failed: expected input tensors to have exactly one dimension (batch)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = loss.Compute(y2, y4)
+		if err == nil {
+			t.Fatalf("expected error because of tensors having more/less than one dimension")
+		} else if err.Error() != "BCE input data validation failed: expected input tensors to have exactly one dimension (batch)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = loss.Compute(y2, y3)
+		if err == nil {
+			t.Fatalf("expected error because of tensors having unequal batch sizes")
+		} else if err.Error() != "BCE input data validation failed: expected input tensor sizes to match along batch dimension: (1) != (2)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		/* ------------------------------ */
+
+	})
+}

--- a/component/losses/ce.go
+++ b/component/losses/ce.go
@@ -1,0 +1,101 @@
+package losses
+
+import (
+	"fmt"
+
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+const epsilon = 1e-12
+
+type CE struct {
+}
+
+func NewCE() (c *CE) {
+	return new(CE)
+}
+
+func (c *CE) Compute(yp tensor.Tensor, yt tensor.Tensor) (l tensor.Tensor, err error) {
+	err = c.validateInputs(yp, yt)
+	if err != nil {
+		err = fmt.Errorf("CE input data validation failed: %w", err)
+		return
+	}
+
+	/* ----- clip tensors ----- */
+
+	yt, err = clip(yt, 0, 1)
+	if err != nil {
+		return
+	}
+
+	yp, err = clip(yp, epsilon, 1-epsilon)
+	if err != nil {
+		return
+	}
+
+	/* ----- sentence ----- */
+
+	s, err := yt.Mul(yp.Log())
+	if err != nil {
+		return
+	}
+
+	/* ----- aggregation ----- */
+
+	l, err = s.SumAlong(1)
+	if err != nil {
+		return
+	}
+
+	l = l.Scale(-1)
+
+	return l.MeanAlong(0)
+}
+
+func clip(x tensor.Tensor, l, u float64) (y tensor.Tensor, err error) {
+	_1 := x.Pow(0)
+	lower := _1.Scale(l)
+	upper := _1.Scale(u)
+
+	y, err = x.ElMin(upper)
+	if err != nil {
+		return
+	}
+
+	y, err = lower.ElMax(y)
+	if err != nil {
+		return
+	}
+
+	return y, nil
+}
+
+/* ----- helpers ----- */
+
+func (c *CE) validateInputs(yp tensor.Tensor, yt tensor.Tensor) (err error) {
+	if yp == nil || yt == nil {
+		err = fmt.Errorf("expected input tensors not to be nil")
+		return
+	}
+
+	shapep := yp.Shape()
+	shapet := yt.Shape()
+
+	if len(shapep) != 2 || len(shapet) != 2 {
+		err = fmt.Errorf("expected input tensors to have exactly two dimensions (batch, class)")
+		return
+	}
+
+	if shapep[0] != shapet[0] {
+		err = fmt.Errorf("expected input tensor sizes to match along batch dimension: (%d) != (%d)", shapep[0], shapet[0])
+		return
+	}
+
+	if shapep[1] != shapet[1] {
+		err = fmt.Errorf("expected input tensor sizes to match along class dimension: (%d) != (%d)", shapep[1], shapet[1])
+		return
+	}
+
+	return nil
+}

--- a/component/losses/ce_test.go
+++ b/component/losses/ce_test.go
@@ -1,0 +1,237 @@
+package losses_test
+
+import (
+	"testing"
+
+	"github.com/sahandsafizadeh/qeep/component/losses"
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+func TestCE(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{Device: dev}
+
+		loss := losses.NewCE()
+
+		/* ------------------------------ */
+
+		yp, err := tensor.TensorOf([][]float64{{0.}}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		yt, err := tensor.TensorOf([][]float64{{0.}}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err := loss.Compute(yp, yt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		val, err := act.At()
+		if err != nil {
+			t.Fatal(err)
+		} else if !(0.-1e-10 < val && val < 0.+1e-10) {
+			t.Fatalf("expected scalar tensors value to be (0): got (%f)", val)
+		}
+
+		/* ------------------------------ */
+
+		yp, err = tensor.TensorOf([][]float64{{1.}}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		yt, err = tensor.TensorOf([][]float64{{1.}}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = loss.Compute(yp, yt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		val, err = act.At()
+		if err != nil {
+			t.Fatal(err)
+		} else if !(0.-1e-10 < val && val < 0.+1e-10) {
+			t.Fatalf("expected scalar tensors value to be (0): got (%f)", val)
+		}
+
+		/* ------------------------------ */
+
+		yp, err = tensor.TensorOf([][]float64{{0., 1.5}}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		yt, err = tensor.TensorOf([][]float64{{2., -1.}}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = loss.Compute(yp, yt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		val, err = act.At()
+		if err != nil {
+			t.Fatal(err)
+		} else if !(27.630 < val && val < 27.632) {
+			t.Fatalf("expected scalar tensors value to be (27.632): got (%f)", val)
+		}
+
+		/* ------------------------------ */
+
+		yp, err = tensor.TensorOf([][]float64{
+			{0.1, 0.8, 0.1},
+			{0.1, 0.2, 0.7},
+			{0.9, 0.1, 0.0},
+		}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		yt, err = tensor.TensorOf([][]float64{
+			{0., 1., 0.},
+			{0., 0., 1.},
+			{1., 0., 0.},
+		}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = loss.Compute(yp, yt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		val, err = act.At()
+		if err != nil {
+			t.Fatal(err)
+		} else if !(0.227 < val && val < 0.229) {
+			t.Fatalf("expected scalar tensors value to be (0.228): got (%f)", val)
+		}
+
+		/* ------------------------------ */
+
+		yp, err = tensor.TensorOf([][]float64{
+			{0.4, 0.1, 0.5},
+			{0.4, 0.4, 0.2},
+			{0.3, 0.3, 0.4},
+		}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		yt, err = tensor.TensorOf([][]float64{
+			{0., 1., 0.},
+			{0., 0., 1.},
+			{1., 0., 0.},
+		}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = loss.Compute(yp, yt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		val, err = act.At()
+		if err != nil {
+			t.Fatal(err)
+		} else if !(1.706 < val && val < 1.707) {
+			t.Fatalf("expected scalar tensors value to be (1.705): got (%f)", val)
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+func TestValidationCE(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{Device: dev}
+
+		loss := losses.NewCE()
+
+		/* ------------------------------ */
+
+		y1, err := tensor.Zeros([]int{1}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		y2, err := tensor.Zeros([]int{1, 1}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		y3, err := tensor.Zeros([]int{2, 1}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		y4, err := tensor.Zeros([]int{1, 2}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		y5, err := tensor.Zeros([]int{1, 1, 1}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = loss.Compute(nil, y1)
+		if err == nil {
+			t.Fatalf("expected error because of nil input tensor")
+		} else if err.Error() != "CE input data validation failed: expected input tensors not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = loss.Compute(y1, nil)
+		if err == nil {
+			t.Fatalf("expected error because of nil input tensor")
+		} else if err.Error() != "CE input data validation failed: expected input tensors not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = loss.Compute(y1, y2)
+		if err == nil {
+			t.Fatalf("expected error because of tensors having more/less than two dimensions")
+		} else if err.Error() != "CE input data validation failed: expected input tensors to have exactly two dimensions (batch, class)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = loss.Compute(y2, y5)
+		if err == nil {
+			t.Fatalf("expected error because of tensors having more/less than two dimensions")
+		} else if err.Error() != "CE input data validation failed: expected input tensors to have exactly two dimensions (batch, class)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = loss.Compute(y2, y3)
+		if err == nil {
+			t.Fatalf("expected error because of tensors having unequal batch sizes")
+		} else if err.Error() != "CE input data validation failed: expected input tensor sizes to match along batch dimension: (1) != (2)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = loss.Compute(y2, y4)
+		if err == nil {
+			t.Fatalf("expected error because of tensors having unequal class sizes")
+		} else if err.Error() != "CE input data validation failed: expected input tensor sizes to match along class dimension: (1) != (2)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		/* ------------------------------ */
+
+	})
+}

--- a/component/losses/ce_test.go
+++ b/component/losses/ce_test.go
@@ -146,7 +146,7 @@ func TestCE(t *testing.T) {
 		val, err = act.At()
 		if err != nil {
 			t.Fatal(err)
-		} else if !(1.706 < val && val < 1.707) {
+		} else if !(1.704 < val && val < 1.706) {
 			t.Fatalf("expected scalar tensors value to be (1.705): got (%f)", val)
 		}
 

--- a/component/losses/mse.go
+++ b/component/losses/mse.go
@@ -1,0 +1,55 @@
+package losses
+
+import (
+	"fmt"
+
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+type MSE struct {
+}
+
+func NewMSE() (c *MSE) {
+	return new(MSE)
+}
+
+func (c *MSE) Compute(yp tensor.Tensor, yt tensor.Tensor) (l tensor.Tensor, err error) {
+	err = c.validateInputs(yp, yt)
+	if err != nil {
+		err = fmt.Errorf("MSE input data validation failed: %w", err)
+		return
+	}
+
+	d, err := yt.Sub(yp)
+	if err != nil {
+		return
+	}
+
+	d = d.Pow(2)
+
+	return d.MeanAlong(0)
+}
+
+/* ----- helpers ----- */
+
+func (c *MSE) validateInputs(yp tensor.Tensor, yt tensor.Tensor) (err error) {
+	if yp == nil || yt == nil {
+		err = fmt.Errorf("expected input tensors not to be nil")
+		return
+	}
+
+	shapep := yp.Shape()
+	shapet := yt.Shape()
+
+	if len(shapep) != 1 || len(shapet) != 1 {
+		err = fmt.Errorf("expected input tensors to have exactly one dimension (batch)")
+		return
+	}
+
+	if shapep[0] != shapet[0] {
+		err = fmt.Errorf("expected input tensor sizes to match along batch dimension: (%d) != (%d)", shapep[0], shapet[0])
+		return
+	}
+
+	return nil
+}

--- a/component/losses/mse_test.go
+++ b/component/losses/mse_test.go
@@ -1,0 +1,145 @@
+package losses_test
+
+import (
+	"testing"
+
+	"github.com/sahandsafizadeh/qeep/component/losses"
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+func TestMSE(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{Device: dev}
+
+		loss := losses.NewMSE()
+
+		/* ------------------------------ */
+
+		yp, err := tensor.TensorOf([]float64{0.5}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		yt, err := tensor.TensorOf([]float64{0.}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err := loss.Compute(yp, yt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err := tensor.TensorOf(0.25, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+		yp, err = tensor.TensorOf([]float64{2., 2., 0.}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		yt, err = tensor.TensorOf([]float64{2., -1., 6.}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = loss.Compute(yp, yt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err = tensor.TensorOf(15., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+func TestValidationMSE(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{Device: dev}
+
+		loss := losses.NewMSE()
+
+		/* ------------------------------ */
+
+		y1, err := tensor.Zeros([]int{}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		y2, err := tensor.Zeros([]int{1}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		y3, err := tensor.Zeros([]int{2}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		y4, err := tensor.Zeros([]int{1, 1}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = loss.Compute(nil, y1)
+		if err == nil {
+			t.Fatalf("expected error because of nil input tensor")
+		} else if err.Error() != "MSE input data validation failed: expected input tensors not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = loss.Compute(y1, nil)
+		if err == nil {
+			t.Fatalf("expected error because of nil input tensor")
+		} else if err.Error() != "MSE input data validation failed: expected input tensors not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = loss.Compute(y1, y2)
+		if err == nil {
+			t.Fatalf("expected error because of tensors having more/less than one dimension")
+		} else if err.Error() != "MSE input data validation failed: expected input tensors to have exactly one dimension (batch)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = loss.Compute(y2, y4)
+		if err == nil {
+			t.Fatalf("expected error because of tensors having more/less than one dimension")
+		} else if err.Error() != "MSE input data validation failed: expected input tensors to have exactly one dimension (batch)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = loss.Compute(y2, y3)
+		if err == nil {
+			t.Fatalf("expected error because of tensors having unequal batch sizes")
+		} else if err.Error() != "MSE input data validation failed: expected input tensor sizes to match along batch dimension: (1) != (2)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		/* ------------------------------ */
+
+	})
+}

--- a/component/metrics/accuracy.go
+++ b/component/metrics/accuracy.go
@@ -1,0 +1,66 @@
+package metrics
+
+import (
+	"fmt"
+
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+type Accuracy struct {
+	total   int
+	correct int
+}
+
+func NewAccuracy() (c *Accuracy) {
+	return new(Accuracy)
+}
+
+func (c *Accuracy) Accumulate(yp tensor.Tensor, yt tensor.Tensor) (err error) {
+	err = c.validateInputs(yp, yt)
+	if err != nil {
+		err = fmt.Errorf("Accuracy input data validation failed: %w", err)
+		return
+	}
+
+	eq, err := yp.Eq(yt)
+	if err != nil {
+		return
+	}
+
+	c.total += eq.Shape()[0]
+	c.correct += int(eq.Sum())
+
+	return nil
+}
+
+func (c *Accuracy) Result() (result float64, err error) {
+	if c.total == 0 {
+		return 0., nil
+	}
+
+	return float64(c.correct) / float64(c.total), nil
+}
+
+/* ----- helpers ----- */
+
+func (c *Accuracy) validateInputs(yp tensor.Tensor, yt tensor.Tensor) (err error) {
+	if yp == nil || yt == nil {
+		err = fmt.Errorf("expected input tensors not to be nil")
+		return
+	}
+
+	shapep := yp.Shape()
+	shapet := yt.Shape()
+
+	if len(shapep) != 1 || len(shapet) != 1 {
+		err = fmt.Errorf("expected input tensors to have exactly one dimension (batch)")
+		return
+	}
+
+	if shapep[0] != shapet[0] {
+		err = fmt.Errorf("expected input tensor sizes to match along batch dimension: (%d) != (%d)", shapep[0], shapet[0])
+		return
+	}
+
+	return nil
+}

--- a/component/metrics/accuracy_test.go
+++ b/component/metrics/accuracy_test.go
@@ -1,0 +1,178 @@
+package metrics_test
+
+import (
+	"testing"
+
+	"github.com/sahandsafizadeh/qeep/component/metrics"
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+func TestAccuracy(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{Device: dev}
+
+		metric := metrics.NewAccuracy()
+
+		/* ------------------------------ */
+
+		result, err := metric.Result()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !(-1e-10 < result && result < 1e-10) {
+			t.Fatalf("expected result to be (0): got (%f)", result)
+		}
+
+		/* ------------------------------ */
+
+		yp, err := tensor.TensorOf([]float64{0.}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		yt, err := tensor.TensorOf([]float64{1.}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = metric.Accumulate(yp, yt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		result, err = metric.Result()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !(-1e-10 < result && result < 1e-10) {
+			t.Fatalf("expected result to be (0): got (%f)", result)
+		}
+
+		/* ------------------------------ */
+
+		yp, err = tensor.TensorOf([]float64{0., 1., 2.}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		yt, err = tensor.TensorOf([]float64{1., 1., 2.}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = metric.Accumulate(yp, yt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		result, err = metric.Result()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !(0.5-1e-10 < result && result < 0.5+1e-10) {
+			t.Fatalf("expected result to be (0.5): got (%f)", result)
+		}
+
+		/* ------------------------------ */
+
+		yp, err = tensor.TensorOf([]float64{3., 2., 1., 0.}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		yt, err = tensor.TensorOf([]float64{3., 2., 1., 0.}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = metric.Accumulate(yp, yt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		result, err = metric.Result()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !(0.75-1e-10 < result && result < 0.75+1e-10) {
+			t.Fatalf("expected result to be (0.75): got (%f)", result)
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+func TestValidationAccuracy(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{Device: dev}
+
+		metric := metrics.NewAccuracy()
+
+		/* ------------------------------ */
+
+		y1, err := tensor.Zeros([]int{}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		y2, err := tensor.Zeros([]int{1}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		y3, err := tensor.Zeros([]int{2}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		y4, err := tensor.Zeros([]int{1, 1}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = metric.Accumulate(nil, y1)
+		if err == nil {
+			t.Fatalf("expected error because of nil input tensor")
+		} else if err.Error() != "Accuracy input data validation failed: expected input tensors not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		err = metric.Accumulate(y1, nil)
+		if err == nil {
+			t.Fatalf("expected error because of nil input tensor")
+		} else if err.Error() != "Accuracy input data validation failed: expected input tensors not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		err = metric.Accumulate(y1, y2)
+		if err == nil {
+			t.Fatalf("expected error because of tensors having more/less than one dimension")
+		} else if err.Error() != "Accuracy input data validation failed: expected input tensors to have exactly one dimension (batch)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		err = metric.Accumulate(y2, y4)
+		if err == nil {
+			t.Fatalf("expected error because of tensors having more/less than one dimension")
+		} else if err.Error() != "Accuracy input data validation failed: expected input tensors to have exactly one dimension (batch)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		err = metric.Accumulate(y2, y3)
+		if err == nil {
+			t.Fatalf("expected error because of tensors having unequal batch sizes")
+		} else if err.Error() != "Accuracy input data validation failed: expected input tensor sizes to match along batch dimension: (1) != (2)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		/* ------------------------------ */
+
+	})
+}

--- a/component/optimizers/sgd.go
+++ b/component/optimizers/sgd.go
@@ -1,0 +1,78 @@
+package optimizers
+
+import (
+	"fmt"
+
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+type SGD struct {
+	learningRate float64
+}
+
+type SGDConfig struct {
+	LearningRate float64
+}
+
+const sgdDefaultLearningRate = 0.01
+
+func NewSGD(conf *SGDConfig) (c *SGD) {
+	conf = toValidSGDConfig(conf)
+
+	return &SGD{
+		learningRate: conf.LearningRate,
+	}
+}
+
+func (c *SGD) Update(wptr *tensor.Tensor) (err error) {
+	w, g, err := c.toValidInputs(wptr)
+	if err != nil {
+		err = fmt.Errorf("SGD input data validation failed: %w", err)
+		return
+	}
+
+	delta := g.Scale(c.learningRate)
+
+	*wptr, err = w.Sub(delta)
+	if err != nil {
+		return
+	}
+
+	return nil
+}
+
+/* ----- helpers ----- */
+
+func (c *SGD) toValidInputs(wptr *tensor.Tensor) (w tensor.Tensor, g tensor.Tensor, err error) {
+	if wptr == nil {
+		err = fmt.Errorf("expected tensor's pointer not to be nil")
+		return
+	}
+
+	w = *wptr
+	if w == nil {
+		err = fmt.Errorf("expected tensor not to be nil")
+		return
+	}
+
+	g = w.Gradient()
+	if g == nil {
+		err = fmt.Errorf("expected tensor's gradient not to be nil")
+		return
+	}
+
+	return w, g, nil
+}
+
+func toValidSGDConfig(iconf *SGDConfig) (conf *SGDConfig) {
+	if iconf == nil {
+		iconf = &SGDConfig{
+			LearningRate: sgdDefaultLearningRate,
+		}
+	}
+
+	conf = new(SGDConfig)
+	*conf = *iconf
+
+	return conf
+}

--- a/component/optimizers/sgd_test.go
+++ b/component/optimizers/sgd_test.go
@@ -1,0 +1,131 @@
+package optimizers_test
+
+import (
+	"testing"
+
+	"github.com/sahandsafizadeh/qeep/component/optimizers"
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+func TestSGD(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{
+			Device:    dev,
+			GradTrack: true,
+		}
+
+		optimizer := optimizers.NewSGD(&optimizers.SGDConfig{LearningRate: 0.1})
+
+		/* ------------------------------ */
+
+		x, err := tensor.Full([]int{32, 32}, 4., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		y := x.Scale(2.).Scale(3.).Scale(5.)
+
+		err = tensor.BackPropagate(y)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = optimizer.Update(&x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act := x
+
+		exp, err := tensor.Full([]int{32, 32}, 1., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+func TestValidationSGD(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		confU := &tensor.Config{
+			Device:    dev,
+			GradTrack: false,
+		}
+
+		confT := &tensor.Config{
+			Device:    dev,
+			GradTrack: true,
+		}
+
+		optimizer := optimizers.NewSGD(nil)
+
+		/* ------------------------------ */
+
+		var wn tensor.Tensor
+
+		wu, err := tensor.Zeros(nil, confU)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wt, err := tensor.Zeros(nil, confT)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = optimizer.Update(nil)
+		if err == nil {
+			t.Fatalf("expected error because of nil input pointer")
+		} else if err.Error() != "SGD input data validation failed: expected tensor's pointer not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		err = optimizer.Update(&wn)
+		if err == nil {
+			t.Fatalf("expected error because of nil input tensor")
+		} else if err.Error() != "SGD input data validation failed: expected tensor not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		err = optimizer.Update(&wu)
+		if err == nil {
+			t.Fatalf("expected error because of nil tensor gradient")
+		} else if err.Error() != "SGD input data validation failed: expected tensor's gradient not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		err = optimizer.Update(&wt)
+		if err == nil {
+			t.Fatalf("expected error because of nil tensor gradient")
+		} else if err.Error() != "SGD input data validation failed: expected tensor's gradient not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		/* ------------------------------ */
+
+		err = tensor.BackPropagate(wu)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = optimizer.Update(&wu)
+		if err == nil {
+			t.Fatalf("expected error because of nil tensor gradient")
+		} else if err.Error() != "SGD input data validation failed: expected tensor's gradient not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		/* ------------------------------ */
+
+	})
+}


### PR DESCRIPTION
- Feat!: add `component` tree
A ***component***, is a separate computational functionality of a neural network. They are categorized into 5 major packages:
1. `initializers`: including **Full**, **Uniform**, **Normal**, **He Uniform**, **He Normal**, **Xavier Uniform** and **Xavier Normal** methods for initializing weights.
2. `layers`: including *activation functions* **Sigmoid**, **Softmax**, **Tanh**, **Relu**, **Leaky Relu** and *trainable modules* such as **Fully Connected**. These components build up a network and tensors pass through them.
3. `losses`: including **Mean Squared Error**, **Binary Cross Entropy** and **Cross Entropy** methods to back-propagate.
4. `metrics`: including **Accuracy** method for evaluating the model.
5. `optimizers`: including **Stochastic Gradient Descent** method for updating network weights.