### PR TITLE
fix(losses): BCE and MSE take 2D inputs

### DIFF
--- a/component/losses/bce.go
+++ b/component/losses/bce.go
@@ -68,6 +68,11 @@ func (c *BCE) Compute(yp tensor.Tensor, yt tensor.Tensor) (l tensor.Tensor, err 
 		return
 	}
 
+	l, err = l.Squeeze(1)
+	if err != nil {
+		return
+	}
+
 	l = l.Scale(-1.)
 
 	return l.MeanAlong(0)
@@ -84,13 +89,18 @@ func (c *BCE) validateInputs(yp tensor.Tensor, yt tensor.Tensor) (err error) {
 	shapep := yp.Shape()
 	shapet := yt.Shape()
 
-	if len(shapep) != 1 || len(shapet) != 1 {
-		err = fmt.Errorf("expected input tensors to have exactly one dimension (batch)")
+	if len(shapep) != 2 || len(shapet) != 2 {
+		err = fmt.Errorf("expected input tensors to have exactly two dimensions (batch, class)")
 		return
 	}
 
 	if shapep[0] != shapet[0] {
 		err = fmt.Errorf("expected input tensor sizes to match along batch dimension: (%d) != (%d)", shapep[0], shapet[0])
+		return
+	}
+
+	if shapep[1] != 1 || shapet[1] != 1 {
+		err = fmt.Errorf("expected input tensor sizes to be equal to (1) along class dimension")
 		return
 	}
 

--- a/component/losses/bce_test.go
+++ b/component/losses/bce_test.go
@@ -16,12 +16,12 @@ func TestBCE(t *testing.T) {
 
 		/* ------------------------------ */
 
-		yp, err := tensor.TensorOf([]float64{0.}, conf)
+		yp, err := tensor.TensorOf([][]float64{{0.}}, conf)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		yt, err := tensor.TensorOf([]float64{0.}, conf)
+		yt, err := tensor.TensorOf([][]float64{{0.}}, conf)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -40,12 +40,12 @@ func TestBCE(t *testing.T) {
 
 		/* ------------------------------ */
 
-		yp, err = tensor.TensorOf([]float64{1.}, conf)
+		yp, err = tensor.TensorOf([][]float64{{1.}}, conf)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		yt, err = tensor.TensorOf([]float64{1.}, conf)
+		yt, err = tensor.TensorOf([][]float64{{1.}}, conf)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -64,36 +64,12 @@ func TestBCE(t *testing.T) {
 
 		/* ------------------------------ */
 
-		yp, err = tensor.TensorOf([]float64{0.}, conf)
+		yp, err = tensor.TensorOf([][]float64{{0.}}, conf)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		yt, err = tensor.TensorOf([]float64{2.}, conf)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		act, err = loss.Compute(yp, yt)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		val, err = act.At()
-		if err != nil {
-			t.Fatal(err)
-		} else if !(27.630 < val && val < 27.632) {
-			t.Fatalf("expected scalar tensors value to be (27.632): got (%f)", val)
-		}
-
-		/* ------------------------------ */
-
-		yp, err = tensor.TensorOf([]float64{1.5}, conf)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		yt, err = tensor.TensorOf([]float64{-1.}, conf)
+		yt, err = tensor.TensorOf([][]float64{{2.}}, conf)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -112,12 +88,36 @@ func TestBCE(t *testing.T) {
 
 		/* ------------------------------ */
 
-		yp, err = tensor.TensorOf([]float64{0.1, 0.2, 0.8, 0.9}, conf)
+		yp, err = tensor.TensorOf([][]float64{{1.5}}, conf)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		yt, err = tensor.TensorOf([]float64{0., 0., 1., 1.}, conf)
+		yt, err = tensor.TensorOf([][]float64{{-1.}}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = loss.Compute(yp, yt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		val, err = act.At()
+		if err != nil {
+			t.Fatal(err)
+		} else if !(27.630 < val && val < 27.632) {
+			t.Fatalf("expected scalar tensors value to be (27.632): got (%f)", val)
+		}
+
+		/* ------------------------------ */
+
+		yp, err = tensor.TensorOf([][]float64{{0.1}, {0.2}, {0.8}, {0.9}}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		yt, err = tensor.TensorOf([][]float64{{0.}, {0.}, {1.}, {1.}}, conf)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -136,12 +136,12 @@ func TestBCE(t *testing.T) {
 
 		/* ------------------------------ */
 
-		yp, err = tensor.TensorOf([]float64{0.9, 0.8, 0.2, 0.1}, conf)
+		yp, err = tensor.TensorOf([][]float64{{0.9}, {0.8}, {0.2}, {0.1}}, conf)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		yt, err = tensor.TensorOf([]float64{0., 0., 1., 1.}, conf)
+		yt, err = tensor.TensorOf([][]float64{{0.}, {0.}, {1.}, {1.}}, conf)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -172,22 +172,27 @@ func TestValidationBCE(t *testing.T) {
 
 		/* ------------------------------ */
 
-		y1, err := tensor.Zeros([]int{}, conf)
+		y1, err := tensor.Zeros([]int{1}, conf)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		y2, err := tensor.Zeros([]int{1}, conf)
+		y2, err := tensor.Zeros([]int{1, 1}, conf)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		y3, err := tensor.Zeros([]int{2}, conf)
+		y3, err := tensor.Zeros([]int{2, 1}, conf)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		y4, err := tensor.Zeros([]int{1, 1}, conf)
+		y4, err := tensor.Zeros([]int{1, 2}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		y5, err := tensor.Zeros([]int{1, 1, 1}, conf)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -208,15 +213,15 @@ func TestValidationBCE(t *testing.T) {
 
 		_, err = loss.Compute(y1, y2)
 		if err == nil {
-			t.Fatalf("expected error because of tensors having more/less than one dimension")
-		} else if err.Error() != "BCE input data validation failed: expected input tensors to have exactly one dimension (batch)" {
+			t.Fatalf("expected error because of tensors having more/less than two dimensions")
+		} else if err.Error() != "BCE input data validation failed: expected input tensors to have exactly two dimensions (batch, class)" {
 			t.Fatal("unexpected error message returned")
 		}
 
-		_, err = loss.Compute(y2, y4)
+		_, err = loss.Compute(y2, y5)
 		if err == nil {
-			t.Fatalf("expected error because of tensors having more/less than one dimension")
-		} else if err.Error() != "BCE input data validation failed: expected input tensors to have exactly one dimension (batch)" {
+			t.Fatalf("expected error because of tensors having more/less than two dimensions")
+		} else if err.Error() != "BCE input data validation failed: expected input tensors to have exactly two dimensions (batch, class)" {
 			t.Fatal("unexpected error message returned")
 		}
 
@@ -224,6 +229,20 @@ func TestValidationBCE(t *testing.T) {
 		if err == nil {
 			t.Fatalf("expected error because of tensors having unequal batch sizes")
 		} else if err.Error() != "BCE input data validation failed: expected input tensor sizes to match along batch dimension: (1) != (2)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = loss.Compute(y2, y4)
+		if err == nil {
+			t.Fatalf("expected error because of tensors having class sizes unequal to (1)")
+		} else if err.Error() != "BCE input data validation failed: expected input tensor sizes to be equal to (1) along class dimension" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = loss.Compute(y4, y2)
+		if err == nil {
+			t.Fatalf("expected error because of tensors having class sizes unequal to (1)")
+		} else if err.Error() != "BCE input data validation failed: expected input tensor sizes to be equal to (1) along class dimension" {
 			t.Fatal("unexpected error message returned")
 		}
 

--- a/component/losses/mse.go
+++ b/component/losses/mse.go
@@ -20,14 +20,19 @@ func (c *MSE) Compute(yp tensor.Tensor, yt tensor.Tensor) (l tensor.Tensor, err 
 		return
 	}
 
-	d, err := yt.Sub(yp)
+	l, err = yt.Sub(yp)
 	if err != nil {
 		return
 	}
 
-	d = d.Pow(2)
+	l, err = l.Squeeze(1)
+	if err != nil {
+		return
+	}
 
-	return d.MeanAlong(0)
+	l = l.Pow(2)
+
+	return l.MeanAlong(0)
 }
 
 /* ----- helpers ----- */
@@ -41,13 +46,18 @@ func (c *MSE) validateInputs(yp tensor.Tensor, yt tensor.Tensor) (err error) {
 	shapep := yp.Shape()
 	shapet := yt.Shape()
 
-	if len(shapep) != 1 || len(shapet) != 1 {
-		err = fmt.Errorf("expected input tensors to have exactly one dimension (batch)")
+	if len(shapep) != 2 || len(shapet) != 2 {
+		err = fmt.Errorf("expected input tensors to have exactly two dimensions (batch, class)")
 		return
 	}
 
 	if shapep[0] != shapet[0] {
 		err = fmt.Errorf("expected input tensor sizes to match along batch dimension: (%d) != (%d)", shapep[0], shapet[0])
+		return
+	}
+
+	if shapep[1] != 1 || shapet[1] != 1 {
+		err = fmt.Errorf("expected input tensor sizes to be equal to (1) along class dimension")
 		return
 	}
 

--- a/component/losses/mse_test.go
+++ b/component/losses/mse_test.go
@@ -16,12 +16,12 @@ func TestMSE(t *testing.T) {
 
 		/* ------------------------------ */
 
-		yp, err := tensor.TensorOf([]float64{0.5}, conf)
+		yp, err := tensor.TensorOf([][]float64{{0.5}}, conf)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		yt, err := tensor.TensorOf([]float64{0.}, conf)
+		yt, err := tensor.TensorOf([][]float64{{0.}}, conf)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -44,12 +44,12 @@ func TestMSE(t *testing.T) {
 
 		/* ------------------------------ */
 
-		yp, err = tensor.TensorOf([]float64{2., 2., 0.}, conf)
+		yp, err = tensor.TensorOf([][]float64{{2.}, {2.}, {0.}}, conf)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		yt, err = tensor.TensorOf([]float64{2., -1., 6.}, conf)
+		yt, err = tensor.TensorOf([][]float64{{2.}, {-1.}, {6.}}, conf)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -84,22 +84,27 @@ func TestValidationMSE(t *testing.T) {
 
 		/* ------------------------------ */
 
-		y1, err := tensor.Zeros([]int{}, conf)
+		y1, err := tensor.Zeros([]int{1}, conf)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		y2, err := tensor.Zeros([]int{1}, conf)
+		y2, err := tensor.Zeros([]int{1, 1}, conf)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		y3, err := tensor.Zeros([]int{2}, conf)
+		y3, err := tensor.Zeros([]int{2, 1}, conf)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		y4, err := tensor.Zeros([]int{1, 1}, conf)
+		y4, err := tensor.Zeros([]int{1, 2}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		y5, err := tensor.Zeros([]int{1, 1, 1}, conf)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -120,15 +125,15 @@ func TestValidationMSE(t *testing.T) {
 
 		_, err = loss.Compute(y1, y2)
 		if err == nil {
-			t.Fatalf("expected error because of tensors having more/less than one dimension")
-		} else if err.Error() != "MSE input data validation failed: expected input tensors to have exactly one dimension (batch)" {
+			t.Fatalf("expected error because of tensors having more/less than two dimensions")
+		} else if err.Error() != "MSE input data validation failed: expected input tensors to have exactly two dimensions (batch, class)" {
 			t.Fatal("unexpected error message returned")
 		}
 
-		_, err = loss.Compute(y2, y4)
+		_, err = loss.Compute(y2, y5)
 		if err == nil {
-			t.Fatalf("expected error because of tensors having more/less than one dimension")
-		} else if err.Error() != "MSE input data validation failed: expected input tensors to have exactly one dimension (batch)" {
+			t.Fatalf("expected error because of tensors having more/less than two dimensions")
+		} else if err.Error() != "MSE input data validation failed: expected input tensors to have exactly two dimensions (batch, class)" {
 			t.Fatal("unexpected error message returned")
 		}
 
@@ -136,6 +141,20 @@ func TestValidationMSE(t *testing.T) {
 		if err == nil {
 			t.Fatalf("expected error because of tensors having unequal batch sizes")
 		} else if err.Error() != "MSE input data validation failed: expected input tensor sizes to match along batch dimension: (1) != (2)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = loss.Compute(y2, y4)
+		if err == nil {
+			t.Fatalf("expected error because of tensors having class sizes unequal to (1)")
+		} else if err.Error() != "MSE input data validation failed: expected input tensor sizes to be equal to (1) along class dimension" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = loss.Compute(y4, y2)
+		if err == nil {
+			t.Fatalf("expected error because of tensors having class sizes unequal to (1)")
+		} else if err.Error() != "MSE input data validation failed: expected input tensor sizes to be equal to (1) along class dimension" {
 			t.Fatal("unexpected error message returned")
 		}
 


### PR DESCRIPTION
- Fix!: for compatiblity with network architecture, `BCE` and `MSE` losses take *2D* inputs of shape (batch, 1) and their results is squeezed in the end.