### PR TITLE
fix(component): remove excessive interface nil checks

### DIFF
--- a/component/layers/activations/leaky_relu.go
+++ b/component/layers/activations/leaky_relu.go
@@ -62,11 +62,6 @@ func (c *LeakyRelu) toValidInputs(xs []tensor.Tensor) (x tensor.Tensor, err erro
 
 	x = xs[0]
 
-	if x == nil {
-		err = fmt.Errorf("expected input tensor not to be nil")
-		return
-	}
-
 	return x, nil
 }
 

--- a/component/layers/activations/leaky_relu_test.go
+++ b/component/layers/activations/leaky_relu_test.go
@@ -78,13 +78,6 @@ func TestValidationLeakyRelu(t *testing.T) {
 			t.Fatal("unexpected error message returned")
 		}
 
-		_, err = activation.Forward(nil)
-		if err == nil {
-			t.Fatalf("expected error because of nil input tensor")
-		} else if err.Error() != "LeakyRelu input data validation failed: expected input tensor not to be nil" {
-			t.Fatal("unexpected error message returned")
-		}
-
 		/* ------------------------------ */
 
 	})

--- a/component/layers/activations/relu.go
+++ b/component/layers/activations/relu.go
@@ -39,10 +39,5 @@ func (c *Relu) toValidInputs(xs []tensor.Tensor) (x tensor.Tensor, err error) {
 
 	x = xs[0]
 
-	if x == nil {
-		err = fmt.Errorf("expected input tensor not to be nil")
-		return
-	}
-
 	return x, nil
 }

--- a/component/layers/activations/relu_test.go
+++ b/component/layers/activations/relu_test.go
@@ -78,13 +78,6 @@ func TestValidationRelu(t *testing.T) {
 			t.Fatal("unexpected error message returned")
 		}
 
-		_, err = activation.Forward(nil)
-		if err == nil {
-			t.Fatalf("expected error because of nil input tensor")
-		} else if err.Error() != "Relu input data validation failed: expected input tensor not to be nil" {
-			t.Fatal("unexpected error message returned")
-		}
-
 		/* ------------------------------ */
 
 	})

--- a/component/layers/activations/sigmoid.go
+++ b/component/layers/activations/sigmoid.go
@@ -46,10 +46,5 @@ func (c *Sigmoid) toValidInputs(xs []tensor.Tensor) (x tensor.Tensor, err error)
 
 	x = xs[0]
 
-	if x == nil {
-		err = fmt.Errorf("expected input tensor not to be nil")
-		return
-	}
-
 	return x, nil
 }

--- a/component/layers/activations/sigmoid_test.go
+++ b/component/layers/activations/sigmoid_test.go
@@ -130,13 +130,6 @@ func TestValidationSigmoid(t *testing.T) {
 			t.Fatal("unexpected error message returned")
 		}
 
-		_, err = activation.Forward(nil)
-		if err == nil {
-			t.Fatalf("expected error because of nil input tensor")
-		} else if err.Error() != "Sigmoid input data validation failed: expected input tensor not to be nil" {
-			t.Fatal("unexpected error message returned")
-		}
-
 		/* ------------------------------ */
 
 	})

--- a/component/layers/activations/softmax.go
+++ b/component/layers/activations/softmax.go
@@ -59,11 +59,6 @@ func (c *Softmax) toValidInputs(xs []tensor.Tensor) (x tensor.Tensor, err error)
 
 	x = xs[0]
 
-	if x == nil {
-		err = fmt.Errorf("expected input tensor not to be nil")
-		return
-	}
-
 	shape := x.Shape()
 
 	if len(shape) <= c.dim {

--- a/component/layers/activations/softmax_test.go
+++ b/component/layers/activations/softmax_test.go
@@ -129,13 +129,6 @@ func TestValidationSoftmax(t *testing.T) {
 			t.Fatal("unexpected error message returned")
 		}
 
-		_, err = activation.Forward(nil)
-		if err == nil {
-			t.Fatalf("expected error because of nil input tensor")
-		} else if err.Error() != "Softmax input data validation failed: expected input tensor not to be nil" {
-			t.Fatal("unexpected error message returned")
-		}
-
 		_, err = activation.Forward(x)
 		if err == nil {
 			t.Fatalf("expected error because of input tensors shape not matching softmax 'Dim'")

--- a/component/layers/activations/tanh.go
+++ b/component/layers/activations/tanh.go
@@ -37,10 +37,5 @@ func (c *Tanh) toValidInputs(xs []tensor.Tensor) (x tensor.Tensor, err error) {
 
 	x = xs[0]
 
-	if x == nil {
-		err = fmt.Errorf("expected input tensor not to be nil")
-		return
-	}
-
 	return x, nil
 }

--- a/component/layers/activations/tanh_test.go
+++ b/component/layers/activations/tanh_test.go
@@ -69,13 +69,6 @@ func TestValidationTanh(t *testing.T) {
 			t.Fatal("unexpected error message returned")
 		}
 
-		_, err = activation.Forward(nil)
-		if err == nil {
-			t.Fatalf("expected error because of nil input tensor")
-		} else if err.Error() != "Tanh input data validation failed: expected input tensor not to be nil" {
-			t.Fatal("unexpected error message returned")
-		}
-
 		/* ------------------------------ */
 
 	})

--- a/component/layers/fc.go
+++ b/component/layers/fc.go
@@ -121,11 +121,6 @@ func (c *FC) toValidInputs(xs []tensor.Tensor) (x tensor.Tensor, err error) {
 
 	x = xs[0]
 
-	if x == nil {
-		err = fmt.Errorf("expected input tensor not to be nil")
-		return
-	}
-
 	shape := x.Shape()
 
 	if len(shape) != 2 {
@@ -159,7 +154,7 @@ func toValidFCConfig(iconf *FCConfig) (conf *FCConfig, err error) {
 		conf.Initializers = make(map[string]Initializer)
 	}
 
-	if initializer, ok := conf.Initializers[fcWeightKey]; !ok {
+	if _, ok := conf.Initializers[fcWeightKey]; !ok {
 		conf.Initializers[fcWeightKey], err = initializers.NewXavierUniform(
 			&initializers.XavierUniformConfig{
 				FanIn:  conf.Inputs,
@@ -168,12 +163,9 @@ func toValidFCConfig(iconf *FCConfig) (conf *FCConfig, err error) {
 		if err != nil {
 			return
 		}
-	} else if initializer == nil {
-		err = fmt.Errorf("expected 'Weight' initializer not to be nil")
-		return
 	}
 
-	if initializer, ok := conf.Initializers[fcBiasKey]; !ok {
+	if _, ok := conf.Initializers[fcBiasKey]; !ok {
 		conf.Initializers[fcBiasKey] = initializers.NewFull(
 			&initializers.FullConfig{
 				Value: 0.,
@@ -181,20 +173,12 @@ func toValidFCConfig(iconf *FCConfig) (conf *FCConfig, err error) {
 		if err != nil {
 			return
 		}
-	} else if initializer == nil {
-		err = fmt.Errorf("expected 'Bias' initializer not to be nil")
-		return
 	}
 
 	return conf, nil
 }
 
 func validateInitializedWeights(w tensor.Tensor, b tensor.Tensor, conf *FCConfig) (err error) {
-	if w == nil || b == nil {
-		err = fmt.Errorf("expected initialized weights not to be nil")
-		return
-	}
-
 	shapew := w.Shape()
 	shapeb := b.Shape()
 

--- a/component/layers/fc_test.go
+++ b/component/layers/fc_test.go
@@ -245,59 +245,7 @@ func TestValidationFC(t *testing.T) {
 			t.Fatal("unexpected error message returned")
 		}
 
-		_, err = layers.NewFC(&layers.FCConfig{
-			Inputs:  1,
-			Outputs: 1,
-			Initializers: map[string]layers.Initializer{
-				"Weight": nil,
-			},
-		})
-		if err == nil {
-			t.Fatalf("expected error because of nil 'Weight' initializer")
-		} else if err.Error() != "FC config data validation failed: expected 'Weight' initializer not to be nil" {
-			t.Fatal("unexpected error message returned")
-		}
-
-		_, err = layers.NewFC(&layers.FCConfig{
-			Inputs:  1,
-			Outputs: 1,
-			Initializers: map[string]layers.Initializer{
-				"Bias": nil,
-			},
-		})
-		if err == nil {
-			t.Fatalf("expected error because of nil 'Bias' initializer")
-		} else if err.Error() != "FC config data validation failed: expected 'Bias' initializer not to be nil" {
-			t.Fatal("unexpected error message returned")
-		}
-
 		/* ------------------------------ */
-
-		_, err = layers.NewFC(&layers.FCConfig{
-			Inputs:  1,
-			Outputs: 1,
-			Initializers: map[string]layers.Initializer{
-				"Weight": new(nilInitializer),
-			},
-		})
-		if err == nil {
-			t.Fatalf("expected error because of weights initialized with nil")
-		} else if err.Error() != "FC initialized weight validation failed: expected initialized weights not to be nil" {
-			t.Fatal("unexpected error message returned")
-		}
-
-		_, err = layers.NewFC(&layers.FCConfig{
-			Inputs:  1,
-			Outputs: 1,
-			Initializers: map[string]layers.Initializer{
-				"Bias": new(nilInitializer),
-			},
-		})
-		if err == nil {
-			t.Fatalf("expected error because of weights initialized with nil")
-		} else if err.Error() != "FC initialized weight validation failed: expected initialized weights not to be nil" {
-			t.Fatal("unexpected error message returned")
-		}
 
 		_, err = layers.NewFC(&layers.FCConfig{
 			Inputs:  1,
@@ -416,13 +364,6 @@ func TestValidationFC(t *testing.T) {
 			t.Fatal("unexpected error message returned")
 		}
 
-		_, err = layer.Forward(nil)
-		if err == nil {
-			t.Fatalf("expected error because of nil input tensor")
-		} else if err.Error() != "FC input data validation failed: expected input tensor not to be nil" {
-			t.Fatal("unexpected error message returned")
-		}
-
 		_, err = layer.Forward(x1)
 		if err == nil {
 			t.Fatalf("expected error because of tensor having more/less than two dimensions")
@@ -444,14 +385,9 @@ func TestValidationFC(t *testing.T) {
 
 /* ----- helpers ----- */
 
-type nilInitializer struct{}
 type zeroDInitializer struct{}
 type twoDInitializer struct{}
 type wrong1DInitializer struct{}
-
-func (c *nilInitializer) Init(shape []int) (x tensor.Tensor, err error) {
-	return nil, nil
-}
 
 func (c *zeroDInitializer) Init(shape []int) (x tensor.Tensor, err error) {
 	return tensor.Zeros(nil, nil)

--- a/component/losses/bce.go
+++ b/component/losses/bce.go
@@ -81,16 +81,11 @@ func (c *BCE) Compute(yp tensor.Tensor, yt tensor.Tensor) (l tensor.Tensor, err 
 /* ----- helpers ----- */
 
 func (c *BCE) validateInputs(yp tensor.Tensor, yt tensor.Tensor) (err error) {
-	if yp == nil || yt == nil {
-		err = fmt.Errorf("expected input tensors not to be nil")
-		return
-	}
-
 	shapep := yp.Shape()
 	shapet := yt.Shape()
 
 	if len(shapep) != 2 || len(shapet) != 2 {
-		err = fmt.Errorf("expected input tensors to have exactly two dimensions (batch, class)")
+		err = fmt.Errorf("expected input tensors to have exactly two dimensions (batch, class=1)")
 		return
 	}
 

--- a/component/losses/bce_test.go
+++ b/component/losses/bce_test.go
@@ -197,31 +197,17 @@ func TestValidationBCE(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, err = loss.Compute(nil, y1)
-		if err == nil {
-			t.Fatalf("expected error because of nil input tensor")
-		} else if err.Error() != "BCE input data validation failed: expected input tensors not to be nil" {
-			t.Fatal("unexpected error message returned")
-		}
-
-		_, err = loss.Compute(y1, nil)
-		if err == nil {
-			t.Fatalf("expected error because of nil input tensor")
-		} else if err.Error() != "BCE input data validation failed: expected input tensors not to be nil" {
-			t.Fatal("unexpected error message returned")
-		}
-
 		_, err = loss.Compute(y1, y2)
 		if err == nil {
 			t.Fatalf("expected error because of tensors having more/less than two dimensions")
-		} else if err.Error() != "BCE input data validation failed: expected input tensors to have exactly two dimensions (batch, class)" {
+		} else if err.Error() != "BCE input data validation failed: expected input tensors to have exactly two dimensions (batch, class=1)" {
 			t.Fatal("unexpected error message returned")
 		}
 
 		_, err = loss.Compute(y2, y5)
 		if err == nil {
 			t.Fatalf("expected error because of tensors having more/less than two dimensions")
-		} else if err.Error() != "BCE input data validation failed: expected input tensors to have exactly two dimensions (batch, class)" {
+		} else if err.Error() != "BCE input data validation failed: expected input tensors to have exactly two dimensions (batch, class=1)" {
 			t.Fatal("unexpected error message returned")
 		}
 

--- a/component/losses/ce.go
+++ b/component/losses/ce.go
@@ -74,11 +74,6 @@ func clip(x tensor.Tensor, l, u float64) (y tensor.Tensor, err error) {
 /* ----- helpers ----- */
 
 func (c *CE) validateInputs(yp tensor.Tensor, yt tensor.Tensor) (err error) {
-	if yp == nil || yt == nil {
-		err = fmt.Errorf("expected input tensors not to be nil")
-		return
-	}
-
 	shapep := yp.Shape()
 	shapet := yt.Shape()
 

--- a/component/losses/ce_test.go
+++ b/component/losses/ce_test.go
@@ -189,20 +189,6 @@ func TestValidationCE(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, err = loss.Compute(nil, y1)
-		if err == nil {
-			t.Fatalf("expected error because of nil input tensor")
-		} else if err.Error() != "CE input data validation failed: expected input tensors not to be nil" {
-			t.Fatal("unexpected error message returned")
-		}
-
-		_, err = loss.Compute(y1, nil)
-		if err == nil {
-			t.Fatalf("expected error because of nil input tensor")
-		} else if err.Error() != "CE input data validation failed: expected input tensors not to be nil" {
-			t.Fatal("unexpected error message returned")
-		}
-
 		_, err = loss.Compute(y1, y2)
 		if err == nil {
 			t.Fatalf("expected error because of tensors having more/less than two dimensions")

--- a/component/losses/mse.go
+++ b/component/losses/mse.go
@@ -38,16 +38,11 @@ func (c *MSE) Compute(yp tensor.Tensor, yt tensor.Tensor) (l tensor.Tensor, err 
 /* ----- helpers ----- */
 
 func (c *MSE) validateInputs(yp tensor.Tensor, yt tensor.Tensor) (err error) {
-	if yp == nil || yt == nil {
-		err = fmt.Errorf("expected input tensors not to be nil")
-		return
-	}
-
 	shapep := yp.Shape()
 	shapet := yt.Shape()
 
 	if len(shapep) != 2 || len(shapet) != 2 {
-		err = fmt.Errorf("expected input tensors to have exactly two dimensions (batch, class)")
+		err = fmt.Errorf("expected input tensors to have exactly two dimensions (batch, class=1)")
 		return
 	}
 

--- a/component/losses/mse_test.go
+++ b/component/losses/mse_test.go
@@ -109,31 +109,17 @@ func TestValidationMSE(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, err = loss.Compute(nil, y1)
-		if err == nil {
-			t.Fatalf("expected error because of nil input tensor")
-		} else if err.Error() != "MSE input data validation failed: expected input tensors not to be nil" {
-			t.Fatal("unexpected error message returned")
-		}
-
-		_, err = loss.Compute(y1, nil)
-		if err == nil {
-			t.Fatalf("expected error because of nil input tensor")
-		} else if err.Error() != "MSE input data validation failed: expected input tensors not to be nil" {
-			t.Fatal("unexpected error message returned")
-		}
-
 		_, err = loss.Compute(y1, y2)
 		if err == nil {
 			t.Fatalf("expected error because of tensors having more/less than two dimensions")
-		} else if err.Error() != "MSE input data validation failed: expected input tensors to have exactly two dimensions (batch, class)" {
+		} else if err.Error() != "MSE input data validation failed: expected input tensors to have exactly two dimensions (batch, class=1)" {
 			t.Fatal("unexpected error message returned")
 		}
 
 		_, err = loss.Compute(y2, y5)
 		if err == nil {
 			t.Fatalf("expected error because of tensors having more/less than two dimensions")
-		} else if err.Error() != "MSE input data validation failed: expected input tensors to have exactly two dimensions (batch, class)" {
+		} else if err.Error() != "MSE input data validation failed: expected input tensors to have exactly two dimensions (batch, class=1)" {
 			t.Fatal("unexpected error message returned")
 		}
 

--- a/component/metrics/accuracy.go
+++ b/component/metrics/accuracy.go
@@ -44,11 +44,6 @@ func (c *Accuracy) Result() (result float64, err error) {
 /* ----- helpers ----- */
 
 func (c *Accuracy) validateInputs(yp tensor.Tensor, yt tensor.Tensor) (err error) {
-	if yp == nil || yt == nil {
-		err = fmt.Errorf("expected input tensors not to be nil")
-		return
-	}
-
 	shapep := yp.Shape()
 	shapet := yt.Shape()
 

--- a/component/metrics/accuracy_test.go
+++ b/component/metrics/accuracy_test.go
@@ -137,20 +137,6 @@ func TestValidationAccuracy(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err = metric.Accumulate(nil, y1)
-		if err == nil {
-			t.Fatalf("expected error because of nil input tensor")
-		} else if err.Error() != "Accuracy input data validation failed: expected input tensors not to be nil" {
-			t.Fatal("unexpected error message returned")
-		}
-
-		err = metric.Accumulate(y1, nil)
-		if err == nil {
-			t.Fatalf("expected error because of nil input tensor")
-		} else if err.Error() != "Accuracy input data validation failed: expected input tensors not to be nil" {
-			t.Fatal("unexpected error message returned")
-		}
-
 		err = metric.Accumulate(y1, y2)
 		if err == nil {
 			t.Fatalf("expected error because of tensors having more/less than one dimension")

--- a/component/optimizers/sgd.go
+++ b/component/optimizers/sgd.go
@@ -44,18 +44,9 @@ func (c *SGD) Update(wptr *tensor.Tensor) (err error) {
 /* ----- helpers ----- */
 
 func (c *SGD) toValidInputs(wptr *tensor.Tensor) (w tensor.Tensor, g tensor.Tensor, err error) {
-	if wptr == nil {
-		err = fmt.Errorf("expected tensor's pointer not to be nil")
-		return
-	}
-
 	w = *wptr
-	if w == nil {
-		err = fmt.Errorf("expected tensor not to be nil")
-		return
-	}
-
 	g = w.Gradient()
+
 	if g == nil {
 		err = fmt.Errorf("expected tensor's gradient not to be nil")
 		return

--- a/component/optimizers/sgd_test.go
+++ b/component/optimizers/sgd_test.go
@@ -71,8 +71,6 @@ func TestValidationSGD(t *testing.T) {
 
 		/* ------------------------------ */
 
-		var wn tensor.Tensor
-
 		wu, err := tensor.Zeros(nil, confU)
 		if err != nil {
 			t.Fatal(err)
@@ -81,20 +79,6 @@ func TestValidationSGD(t *testing.T) {
 		wt, err := tensor.Zeros(nil, confT)
 		if err != nil {
 			t.Fatal(err)
-		}
-
-		err = optimizer.Update(nil)
-		if err == nil {
-			t.Fatalf("expected error because of nil input pointer")
-		} else if err.Error() != "SGD input data validation failed: expected tensor's pointer not to be nil" {
-			t.Fatal("unexpected error message returned")
-		}
-
-		err = optimizer.Update(&wn)
-		if err == nil {
-			t.Fatalf("expected error because of nil input tensor")
-		} else if err.Error() != "SGD input data validation failed: expected tensor not to be nil" {
-			t.Fatal("unexpected error message returned")
 		}
 
 		err = optimizer.Update(&wu)


### PR DESCRIPTION
- Fix!: `nil` value checks for *interface* types in component tree is removed.
this case mostly applies to `tensor.Tensor` and `layers.Initializer` types.
thus, for invalid ***state*** of an interface, behavior is up to the developer and `panic` might occure.
in this project, polymorphic behaviors are validated via contracts and the state of the polymorphic type is not validated. for cases like `nil` value, it must be exceptional like `error` interface where `nil` value has meaning in the business logic.
- Refactor: `BCE` and `MSE` dimension validation error messages improved.