### PR TITLE
feat(tensor): add argmin and argmax reducers

### DIFF
--- a/tensor/internal/cputensor/cputensor.go
+++ b/tensor/internal/cputensor/cputensor.go
@@ -280,11 +280,11 @@ func (t *CPUTensor) Sum() (value float64) {
 }
 
 func (t *CPUTensor) Max() (value float64) {
-	return t.max()
+	return t.max(unwrapValue)
 }
 
 func (t *CPUTensor) Min() (value float64) {
-	return t.min()
+	return t.min(unwrapValue)
 }
 
 func (t *CPUTensor) Avg() (value float64) {
@@ -301,6 +301,26 @@ func (t *CPUTensor) Std() (value float64) {
 
 func (t *CPUTensor) Mean() (value float64) {
 	return t.mean()
+}
+
+func (t *CPUTensor) Argmax(dim int) (o tensor.Tensor, err error) {
+	err = validator.ValidateReducedDimAgainstDims(dim, t.dims)
+	if err != nil {
+		err = fmt.Errorf("Argmax input dimension validation failed: %w", err)
+		return
+	}
+
+	return t.argmax(dim), nil
+}
+
+func (t *CPUTensor) Argmin(dim int) (o tensor.Tensor, err error) {
+	err = validator.ValidateReducedDimAgainstDims(dim, t.dims)
+	if err != nil {
+		err = fmt.Errorf("Argmin input dimension validation failed: %w", err)
+		return
+	}
+
+	return t.argmin(dim), nil
 }
 
 func (t *CPUTensor) SumAlong(dim int) (o tensor.Tensor, err error) {

--- a/tensor/internal/cputensor/types.go
+++ b/tensor/internal/cputensor/types.go
@@ -8,7 +8,14 @@ type CPUTensor struct {
 	gctx *gradtrack.GradContext
 }
 
+type reducerPair struct {
+	index int
+	value float64
+}
+
 type initializerFunc func() any
 type scalarUnaryFunc func(float64) float64
 type scalarBinaryFunc func(float64, float64) float64
-type tensorReducerFunc func(*CPUTensor) float64
+type reducerFunc func(reducerPair, reducerPair) reducerPair
+type reducerUnwrapFunc func(reducerPair) float64
+type reducerTensorFunc func(*CPUTensor) float64

--- a/tensor/internal/tensor/types.go
+++ b/tensor/internal/tensor/types.go
@@ -24,6 +24,8 @@ type Tensor interface {
 	Var() float64
 	Std() float64
 	Mean() float64
+	Argmax(dim int) (Tensor, error)
+	Argmin(dim int) (Tensor, error)
 	SumAlong(dim int) (Tensor, error)
 	MaxAlong(dim int) (Tensor, error)
 	MinAlong(dim int) (Tensor, error)

--- a/tensor/tensor_test/forward_test/reducers_test.go
+++ b/tensor/tensor_test/forward_test/reducers_test.go
@@ -1017,6 +1017,278 @@ func TestMean(t *testing.T) {
 	})
 }
 
+func TestArgmax(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{Device: dev}
+
+		/* ------------------------------ */
+
+		ten, err := tensor.Ones([]int{1}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err := ten.Argmax(0)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err := tensor.TensorOf(0., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+		ten, err = tensor.Ones([]int{3}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = ten.Argmax(0)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err = tensor.TensorOf(0., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+		ten, err = tensor.TensorOf([][][]float64{
+			{
+				{1., 2., -5.},
+				{0., -1., 3.},
+				{7., -7., 7.},
+			},
+			{
+				{8., -1., 0.},
+				{5., 4., -3.},
+				{1., -3., 5.},
+			},
+		}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = ten.Argmax(0)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err = tensor.TensorOf([][]float64{
+			{1., 0., 1.},
+			{1., 1., 0.},
+			{0., 1., 0.},
+		}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* --------------- */
+
+		act, err = ten.Argmax(1)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err = tensor.TensorOf([][]float64{
+			{2., 0., 2.},
+			{0., 1., 2.},
+		}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* --------------- */
+
+		act, err = ten.Argmax(2)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err = tensor.TensorOf([][]float64{
+			{1., 2., 0.},
+			{0., 0., 2.},
+		}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+func TestArgmin(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{Device: dev}
+
+		/* ------------------------------ */
+
+		ten, err := tensor.Ones([]int{1}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err := ten.Argmin(0)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err := tensor.TensorOf(0., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+		ten, err = tensor.Ones([]int{3}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = ten.Argmin(0)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err = tensor.TensorOf(0., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+		ten, err = tensor.TensorOf([][][]float64{
+			{
+				{1., 2., -5.},
+				{0., -1., 3.},
+				{7., -7., 7.},
+			},
+			{
+				{8., -1., 0.},
+				{5., 4., -3.},
+				{1., -3., 5.},
+			},
+		}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act, err = ten.Argmin(0)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err = tensor.TensorOf([][]float64{
+			{0., 1., 0.},
+			{0., 0., 1.},
+			{1., 0., 1.},
+		}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* --------------- */
+
+		act, err = ten.Argmin(1)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err = tensor.TensorOf([][]float64{
+			{1., 2., 0.},
+			{2., 2., 1.},
+		}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* --------------- */
+
+		act, err = ten.Argmin(2)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		exp, err = tensor.TensorOf([][]float64{
+			{2., 1., 1.},
+			{1., 2., 1.},
+		}, conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
 func TestValidationReducers(t *testing.T) {
 	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
 
@@ -1062,6 +1334,20 @@ func TestValidationReducers(t *testing.T) {
 		ten, err = tensor.Zeros([]int{3, 1}, conf)
 		if err != nil {
 			t.Fatal(err)
+		}
+
+		_, err = ten.Argmax(2)
+		if err == nil {
+			t.Fatalf("expected error because of reduced dimension (2) being out of range")
+		} else if err.Error() != "Argmax input dimension validation failed: expected dimension to be in range [0,2): got (2)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = ten.Argmin(2)
+		if err == nil {
+			t.Fatalf("expected error because of reduced dimension (2) being out of range")
+		} else if err.Error() != "Argmin input dimension validation failed: expected dimension to be in range [0,2): got (2)" {
+			t.Fatal("unexpected error message returned")
 		}
 
 		_, err = ten.SumAlong(2)


### PR DESCRIPTION
- Feat!: add `Argmin` and `Argmax` to tensor interface.
these functions are not monitored by `gradtrack` package as they are discrete and non-differentiable.
- Refactor: execute *reducer* operations `reducerPair` type.
this type holds both `index` and `value` for each tensor element. when the final result is calculated on the whole tensor, it will be ***unwrapped*** into a single `float64` value based on the requirement; like the case for `max` and `min` methods. it should be noted that `index` is virtually a counter for tensor elements when we iterate them *linearly*, and it has nothing to do with their physical position.
- Fix: make `max` and `min` methods stable by considering equality case. 