### PR TITLE
feat(optimizers): add momentum to SGD

### DIFF
--- a/component/optimizers/sgd_test.go
+++ b/component/optimizers/sgd_test.go
@@ -15,14 +15,18 @@ func TestSGD(t *testing.T) {
 			GradTrack: true,
 		}
 
-		optimizer := optimizers.NewSGD(&optimizers.SGDConfig{LearningRate: 0.1})
+		optimizer := optimizers.NewSGD(&optimizers.SGDConfig{
+			LearningRate: 0.1,
+		})
 
-		/* ------------------------------ */
-
-		x, err := tensor.Full([]int{32, 32}, 4., conf)
+		x, err := tensor.Full([]int{32, 32}, 5., conf)
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		/* ------------------------------ */
+
+		x.ResetGradContext(true)
 
 		y := x.Scale(2.).Scale(3.).Scale(5.)
 
@@ -38,7 +42,146 @@ func TestSGD(t *testing.T) {
 
 		act := x
 
-		exp, err := tensor.Full([]int{32, 32}, 1., conf)
+		exp, err := tensor.Full([]int{32, 32}, 2., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* --------------- */
+
+		x.ResetGradContext(true)
+
+		y = x.Scale(2.).Scale(2.).Scale(5.)
+
+		err = tensor.BackPropagate(y)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = optimizer.Update(&x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act = x
+
+		exp, err = tensor.Full([]int{32, 32}, 0., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+func TestSGDWithMomentum(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{
+			Device:    dev,
+			GradTrack: true,
+		}
+
+		optimizer := optimizers.NewSGD(&optimizers.SGDConfig{
+			LearningRate: 0.1,
+			Momentum:     0.5,
+		})
+
+		x, err := tensor.Full([]int{32, 32}, 15., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		/* ------------------------------ */
+
+		x.ResetGradContext(true)
+
+		y := x.Scale(2.).Scale(4.).Scale(5.)
+
+		err = tensor.BackPropagate(y)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = optimizer.Update(&x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act := x
+
+		exp, err := tensor.Full([]int{32, 32}, 11., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* --------------- */
+
+		x.ResetGradContext(true)
+
+		y = x.Scale(2.).Scale(3.).Scale(5.)
+
+		err = tensor.BackPropagate(y)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = optimizer.Update(&x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act = x
+
+		exp, err = tensor.Full([]int{32, 32}, 6., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* --------------- */
+
+		x.ResetGradContext(true)
+
+		y = x.Scale(2.).Scale(2.).Scale(5.)
+
+		err = tensor.BackPropagate(y)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = optimizer.Update(&x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act = x
+
+		exp, err = tensor.Full([]int{32, 32}, 1.5, conf)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
- Feat: add **momentum** configuration to `SGD` optimizer. a `map[*tensor.Tensor]tensor.Tensor` is used to track updates (*velocities*) of each optimized parameter. ***Go*** guarantees that pointers won't change as long as they are not candidates for garbage collection; therefore, it's safe to use them as the key type to map.
- Fix: in order to repeat optimization in tests, `ResetGradContext` is invoked on updated tensor.