### PR TITLE
feat(optimizers): add Adam

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,28 @@ func prepareModel() (m *model.Model, err error) {
 		Inputs:  4,
 		Outputs: 3,
 	})(x)
-	output := stream.Softmax(&activations.SoftmaxConfig{Dim: 1})(x)
+	output := stream.Softmax(&activations.SoftmaxConfig{
+		Dim: 1,
+	})(x)
 
-	/* ---------- */
+	/* -------------------- */
+
+	loss := losses.NewCE()
+
+	optimizer, err := optimizers.NewAdam(&optimizers.AdamConfig{
+		LearningRate: 1e-4,
+		WeightDecay:  optimizers.AdamDefaultWeightDecay,
+		Beta1:        optimizers.AdamDefaultBeta1,
+		Beta2:        optimizers.AdamDefaultBeta2,
+		Eps:          optimizers.AdamDefaultEps,
+	})
+	if err != nil {
+		return
+	}
 
 	m, err = model.NewModel(input, output, &model.ModelConfig{
-		Loss:      losses.NewCE(),
-		Optimizer: optimizers.NewSGD(&optimizers.SGDConfig{LearningRate: 1e-5}),
+		Loss:      loss,
+		Optimizer: optimizer,
 	})
 	if err != nil {
 		return

--- a/component/initializers/full.go
+++ b/component/initializers/full.go
@@ -10,7 +10,7 @@ type FullConfig struct {
 	Value float64
 }
 
-const fullDefaultValue = 0.
+const FullDefaultValue = 0.
 
 func NewFull(conf *FullConfig) (c *Full) {
 	conf = toValidFullConfig(conf)
@@ -29,7 +29,7 @@ func (c *Full) Init(shape []int) (x tensor.Tensor, err error) {
 func toValidFullConfig(iconf *FullConfig) (conf *FullConfig) {
 	if iconf == nil {
 		iconf = &FullConfig{
-			Value: fullDefaultValue,
+			Value: FullDefaultValue,
 		}
 	}
 

--- a/component/initializers/normal.go
+++ b/component/initializers/normal.go
@@ -16,8 +16,8 @@ type NormalConfig struct {
 	StdDev float64
 }
 
-const normalDefaultMean = 0.
-const normalDefaultStdDev = 0.05
+const NormalDefaultMean = 0.
+const NormalDefaultStdDev = 0.05
 
 func NewNormal(conf *NormalConfig) (c *Normal, err error) {
 	conf, err = toValidNormalConfig(conf)
@@ -41,8 +41,8 @@ func (c *Normal) Init(shape []int) (x tensor.Tensor, err error) {
 func toValidNormalConfig(iconf *NormalConfig) (conf *NormalConfig, err error) {
 	if iconf == nil {
 		iconf = &NormalConfig{
-			Mean:   normalDefaultMean,
-			StdDev: normalDefaultStdDev,
+			Mean:   NormalDefaultMean,
+			StdDev: NormalDefaultStdDev,
 		}
 	}
 

--- a/component/initializers/uniform.go
+++ b/component/initializers/uniform.go
@@ -16,8 +16,8 @@ type UniformConfig struct {
 	Upper float64
 }
 
-const uniformDefaultLower = -0.05
-const uniformDefaultUpper = 0.05
+const UniformDefaultLower = -0.05
+const UniformDefaultUpper = 0.05
 
 func NewUniform(conf *UniformConfig) (c *Uniform, err error) {
 	conf, err = toValidUniformConfig(conf)
@@ -41,8 +41,8 @@ func (c *Uniform) Init(shape []int) (x tensor.Tensor, err error) {
 func toValidUniformConfig(iconf *UniformConfig) (conf *UniformConfig, err error) {
 	if iconf == nil {
 		iconf = &UniformConfig{
-			Lower: uniformDefaultLower,
-			Upper: uniformDefaultUpper,
+			Lower: UniformDefaultLower,
+			Upper: UniformDefaultUpper,
 		}
 	}
 

--- a/component/layers/activations/leaky_relu.go
+++ b/component/layers/activations/leaky_relu.go
@@ -14,7 +14,7 @@ type LeakyReluConfig struct {
 	M float64
 }
 
-const leakyReluDefaultM = 0.01
+const LeakyReluDefaultM = 0.01
 
 func NewLeakyRelu(conf *LeakyReluConfig) (c *LeakyRelu) {
 	conf = toValidLeakyReluConfig(conf)
@@ -68,7 +68,7 @@ func (c *LeakyRelu) toValidInputs(xs []tensor.Tensor) (x tensor.Tensor, err erro
 func toValidLeakyReluConfig(iconf *LeakyReluConfig) (conf *LeakyReluConfig) {
 	if iconf == nil {
 		iconf = &LeakyReluConfig{
-			M: leakyReluDefaultM,
+			M: LeakyReluDefaultM,
 		}
 	}
 

--- a/component/layers/activations/softmax.go
+++ b/component/layers/activations/softmax.go
@@ -14,7 +14,7 @@ type SoftmaxConfig struct {
 	Dim int
 }
 
-const softmaxDefaultDim = 0
+const SoftmaxDefaultDim = 0
 
 func NewSoftmax(conf *SoftmaxConfig) (c *Softmax, err error) {
 	conf, err = toValidSoftmaxConfig(conf)
@@ -77,7 +77,7 @@ func (c *Softmax) toValidInputs(xs []tensor.Tensor) (x tensor.Tensor, err error)
 func toValidSoftmaxConfig(iconf *SoftmaxConfig) (conf *SoftmaxConfig, err error) {
 	if iconf == nil {
 		iconf = &SoftmaxConfig{
-			Dim: softmaxDefaultDim,
+			Dim: SoftmaxDefaultDim,
 		}
 	}
 

--- a/component/metrics/accuracy.go
+++ b/component/metrics/accuracy.go
@@ -17,7 +17,7 @@ type AccuracyConfig struct {
 	OneHotMode bool
 }
 
-const accuracyDefaultOneHotMode = false
+const AccuracyDefaultOneHotMode = false
 
 func NewAccuracy(conf *AccuracyConfig) (c *Accuracy) {
 	conf = toValidAccuracyConfig(conf)
@@ -111,7 +111,7 @@ func (c *Accuracy) validateInputs(yp tensor.Tensor, yt tensor.Tensor) (err error
 func toValidAccuracyConfig(iconf *AccuracyConfig) (conf *AccuracyConfig) {
 	if iconf == nil {
 		iconf = &AccuracyConfig{
-			OneHotMode: accuracyDefaultOneHotMode,
+			OneHotMode: AccuracyDefaultOneHotMode,
 		}
 	}
 

--- a/component/optimizers/adam.go
+++ b/component/optimizers/adam.go
@@ -1,0 +1,174 @@
+package optimizers
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+type Adam struct {
+	learningRate float64
+	weightDecay  float64
+	beta1        float64
+	beta2        float64
+	eps          float64
+	iteration    map[*tensor.Tensor]int
+	velocities1  map[*tensor.Tensor]tensor.Tensor
+	velocities2  map[*tensor.Tensor]tensor.Tensor
+}
+
+type AdamConfig struct {
+	LearningRate float64
+	WeightDecay  float64
+	Beta1        float64
+	Beta2        float64
+	Eps          float64
+}
+
+const (
+	adamDefaultLearningRate = 0.001
+	adamDefaultWeightDecay  = 0.
+	adamDefaultBeta1        = 0.9
+	adamDefaultBeta2        = 0.999
+	adamDefaultEps          = 1e-8
+)
+
+func NewAdam(conf *AdamConfig) (c *Adam, err error) {
+	conf, err = toValidAdamConfig(conf)
+	if err != nil {
+		err = fmt.Errorf("Adam config data validation failed: %w", err)
+		return
+	}
+
+	return &Adam{
+		learningRate: conf.LearningRate,
+		weightDecay:  conf.WeightDecay,
+		beta1:        conf.Beta1,
+		beta2:        conf.Beta2,
+		eps:          conf.Eps,
+		iteration:    make(map[*tensor.Tensor]int),
+		velocities1:  make(map[*tensor.Tensor]tensor.Tensor),
+		velocities2:  make(map[*tensor.Tensor]tensor.Tensor),
+	}, nil
+}
+
+func (c *Adam) Update(wptr *tensor.Tensor) (err error) {
+	w, g, err := getValidOptimizerInputs(wptr)
+	if err != nil {
+		err = fmt.Errorf("Adam input data validation failed: %w", err)
+		return
+	}
+
+	delta := g
+
+	if c.hasWeightDecay() {
+		wdt := w.Scale(c.weightDecay)
+
+		delta, err = delta.Add(wdt)
+		if err != nil {
+			return
+		}
+	}
+
+	mh := delta.Scale(1 - c.beta1)
+	vh := delta.Pow(2).Scale(1 - c.beta2)
+
+	if m, ok := c.velocities1[wptr]; ok {
+		m = m.Scale(c.beta1)
+
+		mh, err = mh.Add(m)
+		if err != nil {
+			return
+		}
+	}
+
+	if v, ok := c.velocities2[wptr]; ok {
+		v = v.Scale(c.beta2)
+
+		vh, err = vh.Add(v)
+		if err != nil {
+			return
+		}
+	}
+
+	c.velocities1[wptr] = mh
+	c.velocities2[wptr] = vh
+	c.iteration[wptr]++
+
+	t := float64(c.iteration[wptr])
+	beta1t := math.Pow(c.beta1, t)
+	beta2t := math.Pow(c.beta2, t)
+	mh = mh.Scale(1 / (1 - beta1t))
+	vh = vh.Scale(1 / (1 - beta2t)).Pow(0.5)
+
+	n := mh
+	eps := vh.Pow(0).Scale(c.eps)
+
+	d, err := vh.Add(eps)
+	if err != nil {
+		return
+	}
+
+	delta, err = n.Div(d)
+	if err != nil {
+		return
+	}
+
+	delta = delta.Scale(c.learningRate)
+
+	*wptr, err = w.Sub(delta)
+	if err != nil {
+		return
+	}
+
+	return nil
+}
+
+func (c *Adam) hasWeightDecay() (has bool) {
+	return c.weightDecay > 0
+}
+
+/* ----- helpers ----- */
+
+func toValidAdamConfig(iconf *AdamConfig) (conf *AdamConfig, err error) {
+	if iconf == nil {
+		iconf = &AdamConfig{
+			LearningRate: adamDefaultLearningRate,
+			WeightDecay:  adamDefaultWeightDecay,
+			Beta1:        adamDefaultBeta1,
+			Beta2:        adamDefaultBeta2,
+			Eps:          adamDefaultEps,
+		}
+	}
+
+	conf = new(AdamConfig)
+	*conf = *iconf
+
+	if conf.LearningRate <= 0 {
+		err = fmt.Errorf("expected 'LearningRate' to be positive: got (%f)", conf.LearningRate)
+		return
+	}
+
+	if conf.WeightDecay < 0 {
+		err = fmt.Errorf("expected 'WeightDecay' not to be negative: got (%f)", conf.WeightDecay)
+		return
+	}
+
+	if conf.Beta1 < 0 {
+		err = fmt.Errorf("expected 'Beta1' not to be negative: got (%f)", conf.Beta1)
+		return
+	}
+
+	if conf.Beta2 < 0 {
+		err = fmt.Errorf("expected 'Beta2' not to be negative: got (%f)", conf.Beta2)
+		return
+	}
+
+	if conf.Eps <= 0 {
+		err = fmt.Errorf("expected 'Eps' to be positive: got (%f)", conf.Eps)
+		return
+	}
+
+	return conf, nil
+}

--- a/component/optimizers/adam.go
+++ b/component/optimizers/adam.go
@@ -27,11 +27,11 @@ type AdamConfig struct {
 }
 
 const (
-	adamDefaultLearningRate = 0.001
-	adamDefaultWeightDecay  = 0.
-	adamDefaultBeta1        = 0.9
-	adamDefaultBeta2        = 0.999
-	adamDefaultEps          = 1e-8
+	AdamDefaultLearningRate = 0.001
+	AdamDefaultWeightDecay  = 0.
+	AdamDefaultBeta1        = 0.9
+	AdamDefaultBeta2        = 0.999
+	AdamDefaultEps          = 1e-8
 )
 
 func NewAdam(conf *AdamConfig) (c *Adam, err error) {
@@ -134,11 +134,11 @@ func (c *Adam) hasWeightDecay() (has bool) {
 func toValidAdamConfig(iconf *AdamConfig) (conf *AdamConfig, err error) {
 	if iconf == nil {
 		iconf = &AdamConfig{
-			LearningRate: adamDefaultLearningRate,
-			WeightDecay:  adamDefaultWeightDecay,
-			Beta1:        adamDefaultBeta1,
-			Beta2:        adamDefaultBeta2,
-			Eps:          adamDefaultEps,
+			LearningRate: AdamDefaultLearningRate,
+			WeightDecay:  AdamDefaultWeightDecay,
+			Beta1:        AdamDefaultBeta1,
+			Beta2:        AdamDefaultBeta2,
+			Eps:          AdamDefaultEps,
 		}
 	}
 

--- a/component/optimizers/adam_test.go
+++ b/component/optimizers/adam_test.go
@@ -1,0 +1,354 @@
+package optimizers_test
+
+import (
+	"testing"
+
+	"github.com/sahandsafizadeh/qeep/component/optimizers"
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+func TestAdam(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{
+			Device:    dev,
+			GradTrack: true,
+		}
+
+		optimizer, err := optimizers.NewAdam(&optimizers.AdamConfig{
+			LearningRate: 2.,
+			Beta1:        0.5,
+			Beta2:        0.75,
+			Eps:          100.,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		x1, err := tensor.Full([]int{32, 32}, 2., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		x2, err := tensor.Full([]int{16, 16}, 3., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		/* ------------------------------ */
+
+		x1.ResetGradContext(true)
+		x2.ResetGradContext(true)
+
+		y1 := x1.Scale(4.).Scale(5.).Scale(5.)
+		y2 := x2.Scale(4.).Scale(5.).Scale(5.)
+
+		err = tensor.BackPropagate(y1)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = tensor.BackPropagate(y2)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = optimizer.Update(&x1)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = optimizer.Update(&x2)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		/* --------------- */
+
+		act := x1
+
+		exp, err := tensor.Full([]int{32, 32}, 1., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* --------------- */
+
+		act = x2
+
+		exp, err = tensor.Full([]int{16, 16}, 2., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+		x1.ResetGradContext(true)
+		x2.ResetGradContext(true)
+
+		y1 = x1.Scale(4.).Scale(5.).Scale(5.)
+		y2 = x2.Scale(4.).Scale(5.).Scale(5.)
+
+		err = tensor.BackPropagate(y1)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = tensor.BackPropagate(y2)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = optimizer.Update(&x1)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = optimizer.Update(&x2)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		/* --------------- */
+
+		act = x1
+
+		exp, err = tensor.Full([]int{32, 32}, 0., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* --------------- */
+
+		act = x2
+
+		exp, err = tensor.Full([]int{16, 16}, 1., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+		x1.ResetGradContext(true)
+		x2.ResetGradContext(true)
+
+		y1 = x1.Scale(4.).Scale(5.).Scale(5.)
+		y2 = x2.Scale(4.).Scale(5.).Scale(5.)
+
+		err = tensor.BackPropagate(y1)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = tensor.BackPropagate(y2)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = optimizer.Update(&x1)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = optimizer.Update(&x2)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		/* --------------- */
+
+		act = x1
+
+		exp, err = tensor.Full([]int{32, 32}, -1., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* --------------- */
+
+		act = x2
+
+		exp, err = tensor.Full([]int{16, 16}, 0., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if eq, err := act.Equals(exp); err != nil {
+			t.Fatal(err)
+		} else if !eq {
+			t.Fatalf("expected tensors to be equal")
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
+func TestValidationAdam(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		confU := &tensor.Config{
+			Device:    dev,
+			GradTrack: false,
+		}
+
+		confT := &tensor.Config{
+			Device:    dev,
+			GradTrack: true,
+		}
+
+		/* ------------------------------ */
+
+		_, err := optimizers.NewAdam(&optimizers.AdamConfig{})
+		if err == nil {
+			t.Fatalf("expected error because of non-positive 'LearningRate'")
+		} else if err.Error() != "Adam config data validation failed: expected 'LearningRate' to be positive: got (0.000000)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = optimizers.NewAdam(&optimizers.AdamConfig{
+			LearningRate: -1,
+		})
+		if err == nil {
+			t.Fatalf("expected error because of non-positive 'LearningRate'")
+		} else if err.Error() != "Adam config data validation failed: expected 'LearningRate' to be positive: got (-1.000000)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = optimizers.NewAdam(&optimizers.AdamConfig{
+			LearningRate: 1,
+			WeightDecay:  -1,
+		})
+		if err == nil {
+			t.Fatalf("expected error because of negative 'WeightDecay'")
+		} else if err.Error() != "Adam config data validation failed: expected 'WeightDecay' not to be negative: got (-1.000000)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = optimizers.NewAdam(&optimizers.AdamConfig{
+			LearningRate: 10,
+			WeightDecay:  0,
+			Beta1:        -0.5,
+		})
+		if err == nil {
+			t.Fatalf("expected error because of negative 'Beta1'")
+		} else if err.Error() != "Adam config data validation failed: expected 'Beta1' not to be negative: got (-0.500000)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = optimizers.NewAdam(&optimizers.AdamConfig{
+			LearningRate: 10,
+			WeightDecay:  1,
+			Beta1:        0,
+			Beta2:        -0.1,
+		})
+		if err == nil {
+			t.Fatalf("expected error because of negative 'Beta2'")
+		} else if err.Error() != "Adam config data validation failed: expected 'Beta2' not to be negative: got (-0.100000)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = optimizers.NewAdam(&optimizers.AdamConfig{
+			LearningRate: 100,
+			WeightDecay:  10,
+			Beta1:        1,
+			Beta2:        0,
+		})
+		if err == nil {
+			t.Fatalf("expected error because of non-positive 'Eps'")
+		} else if err.Error() != "Adam config data validation failed: expected 'Eps' to be positive: got (0.000000)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = optimizers.NewAdam(&optimizers.AdamConfig{
+			LearningRate: 100,
+			WeightDecay:  10,
+			Beta1:        1,
+			Beta2:        0.5,
+			Eps:          -1,
+		})
+		if err == nil {
+			t.Fatalf("expected error because of non-positive 'Eps'")
+		} else if err.Error() != "Adam config data validation failed: expected 'Eps' to be positive: got (-1.000000)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		/* ------------------------------ */
+
+		optimizer, err := optimizers.NewAdam(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wu, err := tensor.Zeros(nil, confU)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wt, err := tensor.Zeros(nil, confT)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = optimizer.Update(&wu)
+		if err == nil {
+			t.Fatalf("expected error because of nil tensor gradient")
+		} else if err.Error() != "Adam input data validation failed: expected tensor's gradient not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		err = optimizer.Update(&wt)
+		if err == nil {
+			t.Fatalf("expected error because of nil tensor gradient")
+		} else if err.Error() != "Adam input data validation failed: expected tensor's gradient not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		/* ------------------------------ */
+
+		err = tensor.BackPropagate(wu)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = optimizer.Update(&wu)
+		if err == nil {
+			t.Fatalf("expected error because of nil tensor gradient")
+		} else if err.Error() != "Adam input data validation failed: expected tensor's gradient not to be nil" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		/* ------------------------------ */
+
+	})
+}

--- a/component/optimizers/adam_test.go
+++ b/component/optimizers/adam_test.go
@@ -214,6 +214,79 @@ func TestAdam(t *testing.T) {
 	})
 }
 
+func TestAdamDefaultConfiguration(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{
+			Device:    dev,
+			GradTrack: true,
+		}
+
+		optimizer, err := optimizers.NewAdam(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		x, err := tensor.Full(nil, 1., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		/* ------------------------------ */
+
+		x.ResetGradContext(true)
+
+		y := x.Scale(4.).Scale(5.).Scale(5.)
+
+		err = tensor.BackPropagate(y)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = optimizer.Update(&x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act := x
+
+		val, err := act.At()
+		if err != nil {
+			t.Fatal(err)
+		} else if !(0.999-1e-10 < val && val < 0.999+1e-10) {
+			t.Fatalf("expected scalar tensors value to be (0.999): got (%f)", val)
+		}
+
+		/* ------------------------------ */
+
+		x.ResetGradContext(true)
+
+		y = x.Scale(4.).Scale(5.).Scale(5.)
+
+		err = tensor.BackPropagate(y)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = optimizer.Update(&x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act = x
+
+		val, err = act.At()
+		if err != nil {
+			t.Fatal(err)
+		} else if !(0.998-1e-10 < val && val < 0.998+1e-10) {
+			t.Fatalf("expected scalar tensors value to be (0.998): got (%f)", val)
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
 func TestValidationAdam(t *testing.T) {
 	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
 

--- a/component/optimizers/adam_test.go
+++ b/component/optimizers/adam_test.go
@@ -287,6 +287,60 @@ func TestAdamDefaultConfiguration(t *testing.T) {
 	})
 }
 
+func TestAdamWithWeightDecay(t *testing.T) {
+	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		conf := &tensor.Config{
+			Device:    dev,
+			GradTrack: true,
+		}
+
+		optimizer, err := optimizers.NewAdam(&optimizers.AdamConfig{
+			WeightDecay:  1.,
+			LearningRate: optimizers.AdamDefaultLearningRate,
+			Beta1:        optimizers.AdamDefaultBeta1,
+			Beta2:        optimizers.AdamDefaultBeta2,
+			Eps:          optimizers.AdamDefaultEps,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		x, err := tensor.Full(nil, 10., conf)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		/* ------------------------------ */
+
+		x.ResetGradContext(true)
+
+		y := x.Scale(4.).Scale(5.).Scale(5.)
+
+		err = tensor.BackPropagate(y)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = optimizer.Update(&x)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		act := x
+
+		val, err := act.At()
+		if err != nil {
+			t.Fatal(err)
+		} else if !(9.999-1e-10 < val && val < 9.999+1e-10) {
+			t.Fatalf("expected scalar tensors value to be (9.999): got (%f)", val)
+		}
+
+		/* ------------------------------ */
+
+	})
+}
+
 func TestValidationAdam(t *testing.T) {
 	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
 

--- a/component/optimizers/optimizers.go
+++ b/component/optimizers/optimizers.go
@@ -1,0 +1,19 @@
+package optimizers
+
+import (
+	"fmt"
+
+	"github.com/sahandsafizadeh/qeep/tensor"
+)
+
+func getValidOptimizerInputs(wptr *tensor.Tensor) (w tensor.Tensor, g tensor.Tensor, err error) {
+	w = *wptr
+	g = w.Gradient()
+
+	if g == nil {
+		err = fmt.Errorf("expected tensor's gradient not to be nil")
+		return
+	}
+
+	return w, g, nil
+}

--- a/component/optimizers/sgd.go
+++ b/component/optimizers/sgd.go
@@ -42,7 +42,7 @@ func NewSGD(conf *SGDConfig) (c *SGD) {
 }
 
 func (c *SGD) Update(wptr *tensor.Tensor) (err error) {
-	w, g, err := c.toValidInputs(wptr)
+	w, g, err := getValidOptimizerInputs(wptr)
 	if err != nil {
 		err = fmt.Errorf("SGD input data validation failed: %w", err)
 		return
@@ -91,18 +91,6 @@ func (c *SGD) hasMomentum() (has bool) {
 }
 
 /* ----- helpers ----- */
-
-func (c *SGD) toValidInputs(wptr *tensor.Tensor) (w tensor.Tensor, g tensor.Tensor, err error) {
-	w = *wptr
-	g = w.Gradient()
-
-	if g == nil {
-		err = fmt.Errorf("expected tensor's gradient not to be nil")
-		return
-	}
-
-	return w, g, nil
-}
 
 func toValidSGDConfig(iconf *SGDConfig) (conf *SGDConfig) {
 	if iconf == nil {

--- a/component/optimizers/sgd.go
+++ b/component/optimizers/sgd.go
@@ -20,9 +20,9 @@ type SGDConfig struct {
 }
 
 const (
-	sgdDefaultLearningRate = 0.01
-	sgdDefaultWeightDecay  = 0.
-	sgdDefaultMomentum     = 0.
+	SGDDefaultLearningRate = 0.01
+	SGDDefaultWeightDecay  = 0.
+	SGDDefaultMomentum     = 0.
 )
 
 func NewSGD(conf *SGDConfig) (c *SGD, err error) {
@@ -99,9 +99,9 @@ func (c *SGD) hasMomentum() (has bool) {
 func toValidSGDConfig(iconf *SGDConfig) (conf *SGDConfig, err error) {
 	if iconf == nil {
 		iconf = &SGDConfig{
-			LearningRate: sgdDefaultLearningRate,
-			WeightDecay:  sgdDefaultWeightDecay,
-			Momentum:     sgdDefaultMomentum,
+			LearningRate: SGDDefaultLearningRate,
+			WeightDecay:  SGDDefaultWeightDecay,
+			Momentum:     SGDDefaultMomentum,
 		}
 	}
 

--- a/component/optimizers/sgd_test.go
+++ b/component/optimizers/sgd_test.go
@@ -15,9 +15,12 @@ func TestSGD(t *testing.T) {
 			GradTrack: true,
 		}
 
-		optimizer := optimizers.NewSGD(&optimizers.SGDConfig{
+		optimizer, err := optimizers.NewSGD(&optimizers.SGDConfig{
 			LearningRate: 0.1,
 		})
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		x, err := tensor.Full([]int{32, 32}, 5., conf)
 		if err != nil {
@@ -95,10 +98,13 @@ func TestSGDWithMomentum(t *testing.T) {
 			GradTrack: true,
 		}
 
-		optimizer := optimizers.NewSGD(&optimizers.SGDConfig{
+		optimizer, err := optimizers.NewSGD(&optimizers.SGDConfig{
 			LearningRate: 0.1,
 			Momentum:     0.5,
 		})
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		x, err := tensor.Full([]int{32, 32}, 15., conf)
 		if err != nil {
@@ -205,11 +211,14 @@ func TestSGDWithMomentumAndWeightDecay(t *testing.T) {
 			GradTrack: true,
 		}
 
-		optimizer := optimizers.NewSGD(&optimizers.SGDConfig{
+		optimizer, err := optimizers.NewSGD(&optimizers.SGDConfig{
 			LearningRate: 0.1,
 			WeightDecay:  0.2,
 			Momentum:     0.5,
 		})
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		x, err := tensor.Full([]int{32, 32}, 100., conf)
 		if err != nil {
@@ -321,9 +330,51 @@ func TestValidationSGD(t *testing.T) {
 			GradTrack: true,
 		}
 
-		optimizer := optimizers.NewSGD(nil)
+		/* ------------------------------ */
+
+		_, err := optimizers.NewSGD(&optimizers.SGDConfig{})
+		if err == nil {
+			t.Fatalf("expected error because of non-positive 'LearningRate'")
+		} else if err.Error() != "SGD config data validation failed: expected 'LearningRate' to be positive: got (0.000000)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = optimizers.NewSGD(&optimizers.SGDConfig{
+			LearningRate: -1,
+		})
+		if err == nil {
+			t.Fatalf("expected error because of non-positive 'LearningRate'")
+		} else if err.Error() != "SGD config data validation failed: expected 'LearningRate' to be positive: got (-1.000000)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = optimizers.NewSGD(&optimizers.SGDConfig{
+			LearningRate: 1,
+			WeightDecay:  -1,
+		})
+		if err == nil {
+			t.Fatalf("expected error because of negative 'WeightDecay'")
+		} else if err.Error() != "SGD config data validation failed: expected 'WeightDecay' not to be negative: got (-1.000000)" {
+			t.Fatal("unexpected error message returned")
+		}
+
+		_, err = optimizers.NewSGD(&optimizers.SGDConfig{
+			LearningRate: 10,
+			WeightDecay:  1,
+			Momentum:     -0.5,
+		})
+		if err == nil {
+			t.Fatalf("expected error because of negative 'Momentum'")
+		} else if err.Error() != "SGD config data validation failed: expected 'Momentum' not to be negative: got (-0.500000)" {
+			t.Fatal("unexpected error message returned")
+		}
 
 		/* ------------------------------ */
+
+		optimizer, err := optimizers.NewSGD(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		wu, err := tensor.Zeros(nil, confU)
 		if err != nil {

--- a/examples/01-boston-housing/main.go
+++ b/examples/01-boston-housing/main.go
@@ -86,11 +86,18 @@ func prepareModel() (m *model.Model, err error) {
 
 	/* -------------------- */
 
+	loss := losses.NewMSE()
+
+	optimizer, err := optimizers.NewSGD(&optimizers.SGDConfig{
+		LearningRate: 1e-3,
+	})
+	if err != nil {
+		return
+	}
+
 	m, err = model.NewModel(input, output, &model.ModelConfig{
-		Loss: losses.NewMSE(),
-		Optimizer: optimizers.NewSGD(&optimizers.SGDConfig{
-			LearningRate: 1e-3,
-		}),
+		Loss:      loss,
+		Optimizer: optimizer,
 	})
 	if err != nil {
 		return

--- a/examples/01-boston-housing/main.go
+++ b/examples/01-boston-housing/main.go
@@ -21,7 +21,7 @@ const (
 
 const (
 	batchSize = 128
-	epochs    = 500
+	epochs    = 2000
 )
 
 func main() {
@@ -88,9 +88,7 @@ func prepareModel() (m *model.Model, err error) {
 
 	loss := losses.NewMSE()
 
-	optimizer, err := optimizers.NewSGD(&optimizers.SGDConfig{
-		LearningRate: 1e-3,
-	})
+	optimizer, err := optimizers.NewAdam(nil)
 	if err != nil {
 		return
 	}

--- a/examples/02-breast-cancer/main.go
+++ b/examples/02-breast-cancer/main.go
@@ -87,11 +87,18 @@ func prepareModel() (m *model.Model, err error) {
 
 	/* -------------------- */
 
+	loss := losses.NewBCE()
+
+	optimizer, err := optimizers.NewSGD(&optimizers.SGDConfig{
+		LearningRate: 1e-6,
+	})
+	if err != nil {
+		return
+	}
+
 	m, err = model.NewModel(input, output, &model.ModelConfig{
-		Loss: losses.NewBCE(),
-		Optimizer: optimizers.NewSGD(&optimizers.SGDConfig{
-			LearningRate: 1e-6,
-		}),
+		Loss:      loss,
+		Optimizer: optimizer,
 	})
 	if err != nil {
 		return

--- a/examples/02-breast-cancer/main.go
+++ b/examples/02-breast-cancer/main.go
@@ -34,7 +34,7 @@ func main() {
 		fmt.Printf("%s: %.2f\n", m, r)
 	}
 
-	// Best Accuracy: 0.92
+	// Best Accuracy: 0.94
 }
 
 func run() (result map[string]float64, err error) {
@@ -89,9 +89,7 @@ func prepareModel() (m *model.Model, err error) {
 
 	loss := losses.NewBCE()
 
-	optimizer, err := optimizers.NewSGD(&optimizers.SGDConfig{
-		LearningRate: 1e-6,
-	})
+	optimizer, err := optimizers.NewAdam(nil)
 	if err != nil {
 		return
 	}

--- a/examples/03-Iris/main.go
+++ b/examples/03-Iris/main.go
@@ -96,8 +96,12 @@ func prepareModel() (m *model.Model, err error) {
 
 	loss := losses.NewCE()
 
-	optimizer, err := optimizers.NewSGD(&optimizers.SGDConfig{
-		LearningRate: 1e-5,
+	optimizer, err := optimizers.NewAdam(&optimizers.AdamConfig{
+		LearningRate: 1e-4,
+		WeightDecay:  optimizers.AdamDefaultWeightDecay,
+		Beta1:        optimizers.AdamDefaultBeta1,
+		Beta2:        optimizers.AdamDefaultBeta2,
+		Eps:          optimizers.AdamDefaultEps,
 	})
 	if err != nil {
 		return

--- a/examples/03-Iris/main.go
+++ b/examples/03-Iris/main.go
@@ -94,11 +94,18 @@ func prepareModel() (m *model.Model, err error) {
 
 	/* -------------------- */
 
+	loss := losses.NewCE()
+
+	optimizer, err := optimizers.NewSGD(&optimizers.SGDConfig{
+		LearningRate: 1e-5,
+	})
+	if err != nil {
+		return
+	}
+
 	m, err = model.NewModel(input, output, &model.ModelConfig{
-		Loss: losses.NewCE(),
-		Optimizer: optimizers.NewSGD(&optimizers.SGDConfig{
-			LearningRate: 1e-5,
-		}),
+		Loss:      loss,
+		Optimizer: optimizer,
 	})
 	if err != nil {
 		return

--- a/model/internal/node/node_test.go
+++ b/model/internal/node/node_test.go
@@ -213,7 +213,10 @@ func TestNodeOperation(t *testing.T) {
 
 		activation := activations.NewRelu()
 
-		optimizer := optimizers.NewSGD(&optimizers.SGDConfig{LearningRate: 1.})
+		optimizer, err := optimizers.NewSGD(&optimizers.SGDConfig{LearningRate: 1.})
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		/* ------------------------------ */
 
@@ -432,7 +435,10 @@ func TestForwardAndOptimizeErrorHandling(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		optimizer := optimizers.NewSGD(nil)
+		optimizer, err := optimizers.NewSGD(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		/* ------------------------------ */
 

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -58,11 +58,13 @@ func TestModel(t *testing.T) {
 
 		/* --------------- */
 
-		var (
-			loss      = losses.NewMSE()
-			metric    = metrics.NewMSE()
-			optimizer = optimizers.NewSGD(&optimizers.SGDConfig{LearningRate: 0.5})
-		)
+		loss := losses.NewMSE()
+		metric := metrics.NewMSE()
+
+		optimizer, err := optimizers.NewSGD(&optimizers.SGDConfig{LearningRate: 0.5})
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		m, err := model.NewModel(input, output, &model.ModelConfig{
 			Loss:      loss,
@@ -181,9 +183,16 @@ func TestForwardErrorHandling(t *testing.T) {
 		})(input, input)
 		output := stream.Tanh()(hidden)
 
+		loss := losses.NewMSE()
+
+		optimizer, err := optimizers.NewSGD(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		m, err := model.NewModel(input, output, &model.ModelConfig{
-			Loss:      losses.NewMSE(),
-			Optimizer: optimizers.NewSGD(nil),
+			Loss:      loss,
+			Optimizer: optimizer,
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -253,12 +262,14 @@ func TestLossAndMetricErrorHandling(t *testing.T) {
 
 		/* --------------- */
 
-		var (
-			loss      = losses.NewMSE()
-			metric    = metrics.NewMSE()
-			optimizer = optimizers.NewSGD(nil)
-			metrics   = map[string]model.Metric{"MSE": metric}
-		)
+		loss := losses.NewMSE()
+		metric := metrics.NewMSE()
+		metrics := map[string]model.Metric{"MSE": metric}
+
+		optimizer, err := optimizers.NewSGD(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		input := stream.Input()
 		hidden := stream.FC(&layers.FCConfig{


### PR DESCRIPTION
- Feat: add `Adam` optimizer. Adam implementation follows the same method as `SGD` to track the history of *velocities*. Two `map[*tensor.Tensor]tensor.Tensor` are used for that purpose. Also, one `map[*tensor.Tensor]int` is used to track the current iteration (*epoch*) of each parameter based on the original Adam algorithm.
- Fix!: validate `SGD` configurations. `NewSGD` function returns `error` if its input configurations are invalid; for example, negative learning rate is meaningless.
- Fix: change the optimizer of examples to `Adam`. As a result, almost no *tunning* was required.
- Refactor: export all default configuration constants from different *components*.
- Docs: update sources of ***iris*** example in the `README.md` file.