### PR TITLE
fix(devenv): remove default cuda build tags for portability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# AI agents
+.claude/
+
 # shared libraries
 lib/
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "go.buildTags": "cuda",
   "go.formatTool": "gofmt",
   "go.lintTool": "golangci-lint",
   "go.lintFlags": ["--fast"],

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # -------------------- DEV --------------------
-QEEP_BUILD_TAGS := cuda
+# Possible values: cuda, (empty for CPU-only)
+QEEP_BUILD_TAGS :=
 
 fmt:
 	@./scripts/gofmt.sh


### PR DESCRIPTION
**Fix:** Remove default CUDA build tags from Makefile and VS Code settings,
and exclude `.claude/` from version control.

The previous defaults assumed a CUDA-capable environment, causing build failures for developers on CPU-only machines. Excluding `.claude/` allows each developer to maintain their own AI agent customization without polluting the shared repo.