### PR TITLE
fix(component): BatchNorm layer weight dimension

### DIFF
--- a/component/layers/batchnorm.go
+++ b/component/layers/batchnorm.go
@@ -68,7 +68,7 @@ func (c *BatchNorm) Forward(xs ...tensor.Tensor) (y tensor.Tensor, err error) {
 		return y, fmt.Errorf("BatchNorm input data validation failed: %w", err)
 	}
 
-	err = c.initWeights()
+	err = c.initWeights(x)
 	if err != nil {
 		return y, fmt.Errorf("BatchNorm weight initialization failed: %w", err)
 	}
@@ -172,9 +172,12 @@ func (c *BatchNorm) forward(x tensor.Tensor) (y tensor.Tensor, err error) {
 	return y, nil
 }
 
-func (c *BatchNorm) initWeights() (err error) {
+func (c *BatchNorm) initWeights(x tensor.Tensor) (err error) {
+	shape := x.Shape()
+	features := shape[len(shape)-1]
+
 	if c.Beta == nil {
-		c.Beta, err = tensor.Full(nil, 0., &tensor.Config{
+		c.Beta, err = tensor.Full([]int{features}, 0., &tensor.Config{
 			Device:    c.device,
 			GradTrack: true,
 		})
@@ -184,7 +187,7 @@ func (c *BatchNorm) initWeights() (err error) {
 	}
 
 	if c.Gamma == nil {
-		c.Gamma, err = tensor.Full(nil, 1., &tensor.Config{
+		c.Gamma, err = tensor.Full([]int{features}, 1., &tensor.Config{
 			Device:    c.device,
 			GradTrack: true,
 		})
@@ -194,7 +197,7 @@ func (c *BatchNorm) initWeights() (err error) {
 	}
 
 	if c.MovingMean == nil {
-		c.MovingMean, err = tensor.Full(nil, 0., &tensor.Config{
+		c.MovingMean, err = tensor.Full([]int{features}, 0., &tensor.Config{
 			Device:    c.device,
 			GradTrack: false,
 		})
@@ -204,7 +207,7 @@ func (c *BatchNorm) initWeights() (err error) {
 	}
 
 	if c.MovingVar == nil {
-		c.MovingVar, err = tensor.Full(nil, 1., &tensor.Config{
+		c.MovingVar, err = tensor.Full([]int{features}, 1., &tensor.Config{
 			Device:    c.device,
 			GradTrack: false,
 		})

--- a/examples/01-boston-housing/main.go
+++ b/examples/01-boston-housing/main.go
@@ -21,8 +21,8 @@ const (
 )
 
 const (
-	batchSize = 128
-	epochs    = 1000
+	batchSize = 64
+	epochs    = 200
 	dev       = tensor.CPU
 )
 
@@ -36,8 +36,7 @@ func main() {
 		fmt.Printf("%s: %.2f\n", m, r)
 	}
 
-	// Best Mean Squared Error (MSE): 56.35
-	// Total Duration (CPU: 33s, CUDA: 30s)
+	// Best Mean Squared Error (MSE): 75.83
 }
 
 func run() (result map[string]float64, err error) {
@@ -76,9 +75,32 @@ func run() (result map[string]float64, err error) {
 func prepareModel() (m *model.Model, err error) {
 	input := stream.Input()
 
-	x := stream.FC(&layers.FCConfig{Outputs: 32, Device: dev})(input)
+	x := stream.FC(&layers.FCConfig{Outputs: 128, Device: dev})(input)
 	x = stream.Relu()(x)
-	x = stream.Dropout(&layers.DropoutConfig{Rate: 0.5})(x)
+	x = stream.BatchNorm(&layers.BatchNormConfig{
+		Momentum: layers.BatchNormDefaultMomentum,
+		Eps:      layers.BatchNormDefaultEps,
+		Device:   dev,
+	})(x)
+	x = stream.Dropout(&layers.DropoutConfig{Rate: 0.2})(x)
+
+	x = stream.FC(&layers.FCConfig{Outputs: 64, Device: dev})(x)
+	x = stream.Relu()(x)
+	x = stream.BatchNorm(&layers.BatchNormConfig{
+		Momentum: layers.BatchNormDefaultMomentum,
+		Eps:      layers.BatchNormDefaultEps,
+		Device:   dev,
+	})(x)
+	x = stream.Dropout(&layers.DropoutConfig{Rate: 0.2})(x)
+
+	x = stream.FC(&layers.FCConfig{Outputs: 32, Device: dev})(x)
+	x = stream.Relu()(x)
+	x = stream.BatchNorm(&layers.BatchNormConfig{
+		Momentum: layers.BatchNormDefaultMomentum,
+		Eps:      layers.BatchNormDefaultEps,
+		Device:   dev,
+	})(x)
+	x = stream.Dropout(&layers.DropoutConfig{Rate: 0.2})(x)
 
 	output := stream.FC(&layers.FCConfig{Outputs: 1, Device: dev})(x)
 
@@ -86,7 +108,7 @@ func prepareModel() (m *model.Model, err error) {
 
 	loss := losses.NewMSE()
 
-	optimizer, err := optimizers.NewAdamW(nil)
+	optimizer, err := optimizers.NewAdam(nil)
 	if err != nil {
 		return m, err
 	}

--- a/examples/02-breast-cancer/main.go
+++ b/examples/02-breast-cancer/main.go
@@ -21,8 +21,8 @@ const (
 )
 
 const (
-	batchSize = 128
-	epochs    = 500
+	batchSize = 32
+	epochs    = 25
 	dev       = tensor.CPU
 )
 
@@ -36,8 +36,7 @@ func main() {
 		fmt.Printf("%s: %.2f\n", m, r)
 	}
 
-	// Best Accuracy: 0.89
-	// Total Duration (CPU: 30s, CUDA: 40s)
+	// Best Accuracy: 0.47
 }
 
 func run() (result map[string]float64, err error) {
@@ -76,9 +75,23 @@ func run() (result map[string]float64, err error) {
 func prepareModel() (m *model.Model, err error) {
 	input := stream.Input()
 
-	x := stream.FC(&layers.FCConfig{Outputs: 16, Device: dev})(input)
+	x := stream.FC(&layers.FCConfig{Outputs: 64, Device: dev})(input)
 	x = stream.Relu()(x)
-	x = stream.Dropout(&layers.DropoutConfig{Rate: 0.2})(x)
+	x = stream.BatchNorm(&layers.BatchNormConfig{
+		Momentum: layers.BatchNormDefaultMomentum,
+		Eps:      layers.BatchNormDefaultEps,
+		Device:   dev,
+	})(x)
+	x = stream.Dropout(&layers.DropoutConfig{Rate: 0.3})(x)
+
+	x = stream.FC(&layers.FCConfig{Outputs: 32, Device: dev})(x)
+	x = stream.Relu()(x)
+	x = stream.BatchNorm(&layers.BatchNormConfig{
+		Momentum: layers.BatchNormDefaultMomentum,
+		Eps:      layers.BatchNormDefaultEps,
+		Device:   dev,
+	})(x)
+	x = stream.Dropout(&layers.DropoutConfig{Rate: 0.3})(x)
 
 	x = stream.FC(&layers.FCConfig{Outputs: 1, Device: dev})(x)
 	output := stream.Sigmoid()(x)
@@ -87,7 +100,13 @@ func prepareModel() (m *model.Model, err error) {
 
 	loss := losses.NewBCE()
 
-	optimizer, err := optimizers.NewAdam(nil)
+	optimizer, err := optimizers.NewAdamW(&optimizers.AdamWConfig{
+		LearningRate: optimizers.AdamWDefaultLearningRate,
+		WeightDecay:  1e-4,
+		Beta1:        optimizers.AdamWDefaultBeta1,
+		Beta2:        optimizers.AdamWDefaultBeta2,
+		Eps:          optimizers.AdamWDefaultEps,
+	})
 	if err != nil {
 		return m, err
 	}

--- a/examples/03-Iris/main.go
+++ b/examples/03-Iris/main.go
@@ -22,8 +22,8 @@ const (
 )
 
 const (
-	batchSize = 32
-	epochs    = 200
+	batchSize = 16
+	epochs    = 300
 	dev       = tensor.CPU
 )
 
@@ -37,8 +37,7 @@ func main() {
 		fmt.Printf("%s: %.2f\n", m, r)
 	}
 
-	// Best Accuracy: 0.63
-	// Total Duration (CPU: 2s, CUDA: 14s)
+	// Best Accuracy: 0.53
 }
 
 func run() (result map[string]float64, err error) {
@@ -83,7 +82,11 @@ func prepareModel() (m *model.Model, err error) {
 
 	x := stream.FC(&layers.FCConfig{Outputs: 16, Device: dev})(input)
 	x = stream.Relu()(x)
-	x = stream.Dropout(&layers.DropoutConfig{Rate: 0.3})(x)
+	x = stream.Dropout(&layers.DropoutConfig{Rate: 0.2})(x)
+
+	x = stream.FC(&layers.FCConfig{Outputs: 8, Device: dev})(x)
+	x = stream.Relu()(x)
+	x = stream.Dropout(&layers.DropoutConfig{Rate: 0.1})(x)
 
 	x = stream.FC(&layers.FCConfig{Outputs: 3, Device: dev})(x)
 	output := stream.Softmax(&activations.SoftmaxConfig{Dim: 1})(x)
@@ -93,8 +96,8 @@ func prepareModel() (m *model.Model, err error) {
 	loss := losses.NewCE()
 
 	optimizer, err := optimizers.NewAdamW(&optimizers.AdamWConfig{
-		LearningRate: 1e-5,
-		WeightDecay:  optimizers.AdamWDefaultWeightDecay,
+		LearningRate: optimizers.AdamWDefaultLearningRate,
+		WeightDecay:  1e-4,
 		Beta1:        optimizers.AdamWDefaultBeta1,
 		Beta2:        optimizers.AdamWDefaultBeta2,
 		Eps:          optimizers.AdamWDefaultEps,


### PR DESCRIPTION
1. **Fix**: Initialize `BatchNorm` weights with correct dimension.
- Previously, weights initialized with no dimension. Due to _broadcasting_, this didn't cause visible errors; however, all of the features were literally experiencing the same affine transformation from `Beta` and `Gamma`. Following lazy initialization, now the weights are initialized according to the normalization dim of input `tensor`.

2. **Perf**: Update examples
- Following the fix to `BatchNorm` component, examples are updated. Though metrics are worse, training results are more stable.