### PR TITLE
feat(all): zero value to default value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,6 @@ fmt:
 lint:
 	@./scripts/golint.sh $(QEEP_BUILD_TAGS)
 
-gosec:
-	@./scripts/gosec.sh $(QEEP_BUILD_TAGS)
-
 cover:
 	@./scripts/gotest.sh $(QEEP_BUILD_TAGS)
 

--- a/component/initializers/full_test.go
+++ b/component/initializers/full_test.go
@@ -13,6 +13,46 @@ func TestFull(t *testing.T) {
 
 		// ============================== main paths ==============================
 
+		t.Run("NewFull(nil) / Init([1,1]) / returns tensor equal to zero tensor", func(t *testing.T) {
+			initializer := initializers.NewFull(nil)
+
+			act, err := initializer.Init([]int{1, 1}, dev)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Full([]int{1, 1}, 0., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
+			}
+		})
+
+		t.Run("NewFull(&FullConfig{}) / Init([1,1]) / returns tensor equal to zero tensor", func(t *testing.T) {
+			initializer := initializers.NewFull(&initializers.FullConfig{})
+
+			act, err := initializer.Init([]int{1, 1}, dev)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Full([]int{1, 1}, 0., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
+			}
+		})
+
 		t.Run("NewFull(Value=5) / Init([32,32]) / returns tensor with correct shape and non-nil gradient after backprop", func(t *testing.T) {
 			initializer := initializers.NewFull(&initializers.FullConfig{Value: 5.})
 
@@ -32,26 +72,6 @@ func TestFull(t *testing.T) {
 
 			if x.Gradient() == nil {
 				t.Fatal("expected gradient not to be nil")
-			}
-		})
-
-		t.Run("NewFull(nil) / NewFull(&FullConfig{}) / both use FullDefaultValue and produce equal tensors", func(t *testing.T) {
-			initializer1 := initializers.NewFull(nil)
-			initializer2 := initializers.NewFull(&initializers.FullConfig{})
-
-			x1, err := initializer1.Init(nil, dev)
-			if err != nil {
-				t.Fatal(err)
-			}
-			x2, err := initializer2.Init(nil, dev)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if eq, err := x1.Equals(x2); err != nil {
-				t.Fatal(err)
-			} else if !eq {
-				t.Fatal("expected tensors to be equal")
 			}
 		})
 	})

--- a/component/initializers/full_test.go
+++ b/component/initializers/full_test.go
@@ -13,26 +13,6 @@ func TestFull(t *testing.T) {
 
 		// ============================== main paths ==============================
 
-		t.Run("NewFull(Value=-1) / Init([]) / returns scalar tensor with value -1", func(t *testing.T) {
-			initializer := initializers.NewFull(&initializers.FullConfig{Value: -1.})
-
-			x, err := initializer.Init(nil, dev)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			exp, err := tensor.Of(-1., &tensor.Config{Device: dev})
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if eq, err := x.Equals(exp); err != nil {
-				t.Fatal(err)
-			} else if !eq {
-				t.Fatal("expected tensors to be equal")
-			}
-		})
-
 		t.Run("NewFull(Value=5) / Init([32,32]) / returns tensor with correct shape and non-nil gradient after backprop", func(t *testing.T) {
 			initializer := initializers.NewFull(&initializers.FullConfig{Value: 5.})
 
@@ -55,20 +35,20 @@ func TestFull(t *testing.T) {
 			}
 		})
 
-		t.Run("NewFull(nil) / Init([]) / returns scalar tensor with default value 0", func(t *testing.T) {
-			initializer := initializers.NewFull(nil)
+		t.Run("NewFull(nil) / NewFull(&FullConfig{}) / both use FullDefaultValue and produce equal tensors", func(t *testing.T) {
+			initializer1 := initializers.NewFull(nil)
+			initializer2 := initializers.NewFull(&initializers.FullConfig{})
 
-			x, err := initializer.Init(nil, dev)
+			x1, err := initializer1.Init(nil, dev)
+			if err != nil {
+				t.Fatal(err)
+			}
+			x2, err := initializer2.Init(nil, dev)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			exp, err := tensor.Of(0., &tensor.Config{Device: dev})
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if eq, err := x.Equals(exp); err != nil {
+			if eq, err := x1.Equals(x2); err != nil {
 				t.Fatal(err)
 			} else if !eq {
 				t.Fatal("expected tensors to be equal")

--- a/component/initializers/full_test.go
+++ b/component/initializers/full_test.go
@@ -13,8 +13,28 @@ func TestFull(t *testing.T) {
 
 		// ============================== main paths ==============================
 
-		t.Run("NewFull(nil) default-value initializer / Init([32,32]) / returns tensor with correct shape and non-nil gradient after backprop", func(t *testing.T) {
-			initializer := initializers.NewFull(nil)
+		t.Run("NewFull(Value=-1) / Init([]) / returns scalar tensor with value -1", func(t *testing.T) {
+			initializer := initializers.NewFull(&initializers.FullConfig{Value: -1.})
+
+			x, err := initializer.Init(nil, dev)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(-1., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := x.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
+			}
+		})
+
+		t.Run("NewFull(Value=5) / Init([32,32]) / returns tensor with correct shape and non-nil gradient after backprop", func(t *testing.T) {
+			initializer := initializers.NewFull(&initializers.FullConfig{Value: 5.})
 
 			x, err := initializer.Init([]int{32, 32}, dev)
 			if err != nil {
@@ -32,6 +52,26 @@ func TestFull(t *testing.T) {
 
 			if x.Gradient() == nil {
 				t.Fatal("expected gradient not to be nil")
+			}
+		})
+
+		t.Run("NewFull(nil) / Init([]) / returns scalar tensor with default value 0", func(t *testing.T) {
+			initializer := initializers.NewFull(nil)
+
+			x, err := initializer.Init(nil, dev)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(0., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := x.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 	})

--- a/component/layers/activations/leaky_relu_test.go
+++ b/component/layers/activations/leaky_relu_test.go
@@ -12,6 +12,39 @@ func TestLeakyRelu(t *testing.T) {
 
 		// ============================== main paths ==============================
 
+		t.Run("LeakyRelu(nil) on mixed negative/zero/positive matrix / Forward() / scales negatives by default 0.01, passes positives unchanged", func(t *testing.T) {
+			activation := activations.NewLeakyRelu(nil)
+
+			x, err := tensor.Of([][]float64{
+				{-2., -1., -0.01},
+				{0., 0., 0.},
+				{0.01, 1., 2.},
+			}, &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			act, err := activation.Forward(x)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of([][]float64{
+				{-0.02, -0.01, -0.0001},
+				{0., 0., 0.},
+				{0.01, 1., 2.},
+			}, &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
+			}
+		})
+
 		t.Run("LeakyRelu(M=0.5) on mixed negative/zero/positive matrix / Forward() / scales negatives by 0.5, passes positives unchanged", func(t *testing.T) {
 			activation := activations.NewLeakyRelu(&activations.LeakyReluConfig{M: 0.5})
 

--- a/component/layers/activations/softmax.go
+++ b/component/layers/activations/softmax.go
@@ -14,8 +14,6 @@ type SoftmaxConfig struct {
 	Dim int
 }
 
-const SoftmaxDefaultDim = 0
-
 func NewSoftmax(conf *SoftmaxConfig) (c *Softmax, err error) {
 	conf, err = toValidSoftmaxConfig(conf)
 	if err != nil {
@@ -77,9 +75,7 @@ func (c *Softmax) toValidInputs(xs []tensor.Tensor) (x tensor.Tensor, err error)
 
 func toValidSoftmaxConfig(iconf *SoftmaxConfig) (conf *SoftmaxConfig, err error) {
 	if iconf == nil {
-		iconf = &SoftmaxConfig{
-			Dim: SoftmaxDefaultDim,
-		}
+		return conf, fmt.Errorf("expected config not to be nil")
 	}
 
 	conf = new(SoftmaxConfig)

--- a/component/layers/activations/softmax_test.go
+++ b/component/layers/activations/softmax_test.go
@@ -145,7 +145,7 @@ func TestSoftmax(t *testing.T) {
 		})
 
 		t.Run("no input tensors / Forward() / returns error: expected exactly one input tensor", func(t *testing.T) {
-			activation, err := activations.NewSoftmax(&activations.SoftmaxConfig{Dim: 0})
+			activation, err := activations.NewSoftmax(&activations.SoftmaxConfig{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -159,7 +159,7 @@ func TestSoftmax(t *testing.T) {
 		})
 
 		t.Run("two input tensors / Forward() / returns error: expected exactly one input tensor", func(t *testing.T) {
-			activation, err := activations.NewSoftmax(&activations.SoftmaxConfig{Dim: 0})
+			activation, err := activations.NewSoftmax(&activations.SoftmaxConfig{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -178,7 +178,7 @@ func TestSoftmax(t *testing.T) {
 		})
 
 		t.Run("scalar input with Dim=0 / Forward() / returns error: input shape does not match Dim", func(t *testing.T) {
-			activation, err := activations.NewSoftmax(&activations.SoftmaxConfig{Dim: 0})
+			activation, err := activations.NewSoftmax(&activations.SoftmaxConfig{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/component/layers/activations/softmax_test.go
+++ b/component/layers/activations/softmax_test.go
@@ -126,6 +126,15 @@ func TestSoftmax(t *testing.T) {
 
 		// ============================== validations ==============================
 
+		t.Run("NewSoftmax(nil) / returns error: nil config", func(t *testing.T) {
+			_, err := activations.NewSoftmax(nil)
+			if err == nil {
+				t.Fatal("expected error because of nil input config")
+			} else if err.Error() != "Softmax config data validation failed: expected config not to be nil" {
+				t.Fatal("unexpected error message returned")
+			}
+		})
+
 		t.Run("NewSoftmax with negative Dim / returns error: expected Dim not to be negative", func(t *testing.T) {
 			_, err := activations.NewSoftmax(&activations.SoftmaxConfig{Dim: -1})
 			if err == nil {
@@ -136,7 +145,7 @@ func TestSoftmax(t *testing.T) {
 		})
 
 		t.Run("no input tensors / Forward() / returns error: expected exactly one input tensor", func(t *testing.T) {
-			activation, err := activations.NewSoftmax(nil)
+			activation, err := activations.NewSoftmax(&activations.SoftmaxConfig{Dim: 0})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -150,7 +159,7 @@ func TestSoftmax(t *testing.T) {
 		})
 
 		t.Run("two input tensors / Forward() / returns error: expected exactly one input tensor", func(t *testing.T) {
-			activation, err := activations.NewSoftmax(nil)
+			activation, err := activations.NewSoftmax(&activations.SoftmaxConfig{Dim: 0})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -169,7 +178,7 @@ func TestSoftmax(t *testing.T) {
 		})
 
 		t.Run("scalar input with Dim=0 / Forward() / returns error: input shape does not match Dim", func(t *testing.T) {
-			activation, err := activations.NewSoftmax(nil)
+			activation, err := activations.NewSoftmax(&activations.SoftmaxConfig{Dim: 0})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/component/layers/batchnorm.go
+++ b/component/layers/batchnorm.go
@@ -256,22 +256,32 @@ func (c *BatchNorm) toValidInputs(xs []tensor.Tensor) (x tensor.Tensor, err erro
 
 func toValidBatchNormConfig(iconf *BatchNormConfig) (conf *BatchNormConfig, err error) {
 	if iconf == nil {
-		return conf, fmt.Errorf("expected config not to be nil")
+		iconf = &BatchNormConfig{
+			Momentum: BatchNormDefaultMomentum,
+			Eps:      BatchNormDefaultEps,
+			Device:   tensor.CPU,
+		}
 	}
 
 	conf = new(BatchNormConfig)
 	*conf = *iconf
 
-	if conf.Momentum < 0 {
-		return conf, fmt.Errorf("expected 'Momentum' not to be negative: got (%f)", conf.Momentum)
+	if conf.Momentum == 0. {
+		conf.Momentum = BatchNormDefaultMomentum
 	}
-
-	if conf.Eps <= 0 {
-		return conf, fmt.Errorf("expected 'Eps' to be positive: got (%f)", conf.Eps)
+	if conf.Eps == 0. {
+		conf.Eps = BatchNormDefaultEps
 	}
-
 	if conf.Device == 0 {
 		conf.Device = tensor.CPU
+	}
+
+	if conf.Momentum < 0 {
+		return conf, fmt.Errorf("expected 'Momentum' to be positive: got (%f)", conf.Momentum)
+	}
+
+	if conf.Eps < 0 {
+		return conf, fmt.Errorf("expected 'Eps' to be positive: got (%f)", conf.Eps)
 	}
 
 	return conf, nil

--- a/component/layers/batchnorm_test.go
+++ b/component/layers/batchnorm_test.go
@@ -643,6 +643,118 @@ func TestBatchNorm(t *testing.T) {
 			}
 		})
 
+		t.Run("BatchNorm(default config nil) / train [[1,0],[-1,0]] then test [[0,0]] / test near 0", func(t *testing.T) {
+			layer, err := layers.NewBatchNorm(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// tracked pass to update running stat
+			xinit, err := tensor.Of([][]float64{
+				{1., 0.},
+				{-1., 0.},
+			}, &tensor.Config{
+				Device:    tensor.CPU,
+				GradTrack: true,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = layer.Forward(xinit)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			x, err := tensor.Of([][]float64{{0., 0.}}, &tensor.Config{
+				Device:    tensor.CPU,
+				GradTrack: false,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			act, err := layer.Forward(x)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			expl, err := tensor.Of([][]float64{{-0.0001, -0.0001}}, &tensor.Config{Device: tensor.CPU})
+			if err != nil {
+				t.Fatal(err)
+			}
+			expu, err := tensor.Of([][]float64{{0.0001, 0.0001}}, &tensor.Config{Device: tensor.CPU})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if p, err := act.Gt(expl); err != nil {
+				t.Fatal(err)
+			} else if p.Sum() < float64(p.NElems()) {
+				t.Fatal("expected test output to be in range")
+			}
+			if p, err := act.Lt(expu); err != nil {
+				t.Fatal(err)
+			} else if p.Sum() < float64(p.NElems()) {
+				t.Fatal("expected test output to be in range")
+			}
+		})
+
+		t.Run("BatchNorm(default config nil) / train [[1,0],[-1,0]] then test [[0,0]] / test near 0", func(t *testing.T) {
+			layer, err := layers.NewBatchNorm(&layers.BatchNormConfig{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// tracked pass to update running stat
+			xinit, err := tensor.Of([][]float64{
+				{1., 0.},
+				{-1., 0.},
+			}, &tensor.Config{
+				Device:    tensor.CPU,
+				GradTrack: true,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = layer.Forward(xinit)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			x, err := tensor.Of([][]float64{{0., 0.}}, &tensor.Config{
+				Device:    tensor.CPU,
+				GradTrack: false,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			act, err := layer.Forward(x)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			expl, err := tensor.Of([][]float64{{-0.0001, -0.0001}}, &tensor.Config{Device: tensor.CPU})
+			if err != nil {
+				t.Fatal(err)
+			}
+			expu, err := tensor.Of([][]float64{{0.0001, 0.0001}}, &tensor.Config{Device: tensor.CPU})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if p, err := act.Gt(expl); err != nil {
+				t.Fatal(err)
+			} else if p.Sum() < float64(p.NElems()) {
+				t.Fatal("expected test output to be in range")
+			}
+			if p, err := act.Lt(expu); err != nil {
+				t.Fatal(err)
+			} else if p.Sum() < float64(p.NElems()) {
+				t.Fatal("expected test output to be in range")
+			}
+		})
+
 		t.Run("BatchNorm layer / Weights() / before first forward, all 4 weights are uninitialized", func(t *testing.T) {
 			layer, err := layers.NewBatchNorm(&layers.BatchNormConfig{
 				Momentum: 0.5,

--- a/component/layers/batchnorm_test.go
+++ b/component/layers/batchnorm_test.go
@@ -865,22 +865,13 @@ func TestBatchNorm(t *testing.T) {
 
 		// ============================== validations ==============================
 
-		t.Run("NewBatchNorm(nil) / returns error: config must not be nil", func(t *testing.T) {
-			_, err := layers.NewBatchNorm(nil)
-			if err == nil {
-				t.Fatal("expected error because of nil input config")
-			} else if err.Error() != "BatchNorm config data validation failed: expected config not to be nil" {
-				t.Fatal("unexpected error message returned")
-			}
-		})
-
 		t.Run("NewBatchNorm(Momentum=-0.01) / returns error: Momentum must not be negative", func(t *testing.T) {
 			_, err := layers.NewBatchNorm(&layers.BatchNormConfig{
 				Momentum: -0.01,
 			})
 			if err == nil {
 				t.Fatal("expected error because of negative 'Momentum'")
-			} else if err.Error() != "BatchNorm config data validation failed: expected 'Momentum' not to be negative: got (-0.010000)" {
+			} else if err.Error() != "BatchNorm config data validation failed: expected 'Momentum' to be positive: got (-0.010000)" {
 				t.Fatal("unexpected error message returned")
 			}
 		})
@@ -893,18 +884,6 @@ func TestBatchNorm(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected error because of non-positive 'Eps'")
 			} else if err.Error() != "BatchNorm config data validation failed: expected 'Eps' to be positive: got (-0.001000)" {
-				t.Fatal("unexpected error message returned")
-			}
-		})
-
-		t.Run("NewBatchNorm(Eps=0) / returns error: Eps must be positive", func(t *testing.T) {
-			_, err := layers.NewBatchNorm(&layers.BatchNormConfig{
-				Momentum: 0,
-				Eps:      0,
-			})
-			if err == nil {
-				t.Fatal("expected error because of non-positive 'Eps'")
-			} else if err.Error() != "BatchNorm config data validation failed: expected 'Eps' to be positive: got (0.000000)" {
 				t.Fatal("unexpected error message returned")
 			}
 		})

--- a/component/layers/batchnorm_test.go
+++ b/component/layers/batchnorm_test.go
@@ -699,7 +699,7 @@ func TestBatchNorm(t *testing.T) {
 			}
 		})
 
-		t.Run("BatchNorm(default config nil) / train [[1,0],[-1,0]] then test [[0,0]] / test near 0", func(t *testing.T) {
+		t.Run("BatchNorm(default config empty) / train [[1,0],[-1,0]] then test [[0,0]] / test near 0", func(t *testing.T) {
 			layer, err := layers.NewBatchNorm(&layers.BatchNormConfig{})
 			if err != nil {
 				t.Fatal(err)

--- a/component/layers/fc.go
+++ b/component/layers/fc.go
@@ -194,12 +194,12 @@ func toValidFCConfig(iconf *FCConfig) (conf *FCConfig, err error) {
 	conf = new(FCConfig)
 	*conf = *iconf
 
-	if conf.Outputs <= 0 {
-		return conf, fmt.Errorf("expected 'Outputs' to be positive: got (%d)", conf.Outputs)
-	}
-
 	if conf.Device == 0 {
 		conf.Device = tensor.CPU
+	}
+
+	if conf.Outputs <= 0 {
+		return conf, fmt.Errorf("expected 'Outputs' to be positive: got (%d)", conf.Outputs)
 	}
 
 	return conf, nil

--- a/component/optimizers/adam.go
+++ b/component/optimizers/adam.go
@@ -166,23 +166,39 @@ func toValidAdamConfig(iconf *AdamConfig) (conf *AdamConfig, err error) {
 	conf = new(AdamConfig)
 	*conf = *iconf
 
-	if conf.LearningRate <= 0 {
+	if conf.LearningRate == 0. {
+		conf.LearningRate = AdamDefaultLearningRate
+	}
+	if conf.WeightDecay == 0. {
+		conf.WeightDecay = AdamDefaultWeightDecay
+	}
+	if conf.Beta1 == 0. {
+		conf.Beta1 = AdamDefaultBeta1
+	}
+	if conf.Beta2 == 0. {
+		conf.Beta2 = AdamDefaultBeta2
+	}
+	if conf.Eps == 0. {
+		conf.Eps = AdamDefaultEps
+	}
+
+	if conf.LearningRate < 0 {
 		return conf, fmt.Errorf("expected 'LearningRate' to be positive: got (%f)", conf.LearningRate)
 	}
 
 	if conf.WeightDecay < 0 {
-		return conf, fmt.Errorf("expected 'WeightDecay' not to be negative: got (%f)", conf.WeightDecay)
+		return conf, fmt.Errorf("expected 'WeightDecay' to be positive: got (%f)", conf.WeightDecay)
 	}
 
 	if conf.Beta1 < 0 {
-		return conf, fmt.Errorf("expected 'Beta1' not to be negative: got (%f)", conf.Beta1)
+		return conf, fmt.Errorf("expected 'Beta1' to be positive: got (%f)", conf.Beta1)
 	}
 
 	if conf.Beta2 < 0 {
-		return conf, fmt.Errorf("expected 'Beta2' not to be negative: got (%f)", conf.Beta2)
+		return conf, fmt.Errorf("expected 'Beta2' to be positive: got (%f)", conf.Beta2)
 	}
 
-	if conf.Eps <= 0 {
+	if conf.Eps < 0 {
 		return conf, fmt.Errorf("expected 'Eps' to be positive: got (%f)", conf.Eps)
 	}
 

--- a/component/optimizers/adam_test.go
+++ b/component/optimizers/adam_test.go
@@ -194,6 +194,58 @@ func TestAdam(t *testing.T) {
 			}
 		})
 
+		t.Run("Adam lr=2 weightDecay=2 beta1=0.5 beta2=0.75 eps=100, scalar x=2 / one update step with grad 100 / x becomes ~0.9803", func(t *testing.T) {
+			optimizer, err := optimizers.NewAdam(&optimizers.AdamConfig{
+				LearningRate: 2.,
+				WeightDecay:  2.,
+				Beta1:        0.5,
+				Beta2:        0.75,
+				Eps:          100.,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			x, err := tensor.Full(nil, 2., &tensor.Config{
+				Device:    dev,
+				GradTrack: true,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			y := x.Scale(4.).Scale(5.).Scale(5.)
+
+			err = tensor.BackPropagate(y)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = optimizer.Update(&x)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			expl, err := tensor.Full(nil, 0.9803-1e-4, &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+			expu, err := tensor.Full(nil, 0.9803+1e-4, &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if p, err := x.Gt(expl); err != nil {
+				t.Fatal(err)
+			} else if p.Sum() < float64(p.NElems()) {
+				t.Fatal("expected output to be in range")
+			}
+			if p, err := x.Lt(expu); err != nil {
+				t.Fatal(err)
+			} else if p.Sum() < float64(p.NElems()) {
+				t.Fatal("expected output to be in range")
+			}
+		})
+
 		t.Run("Adam nil config (defaults), scalar x=1 / 2 consecutive update steps with grad 100 / x converges by 0.001 each step: 1→0.999→0.998", func(t *testing.T) {
 			optimizer, err := optimizers.NewAdam(nil)
 			if err != nil {
@@ -274,19 +326,13 @@ func TestAdam(t *testing.T) {
 			}
 		})
 
-		t.Run("Adam lr=2 weightDecay=2 beta1=0.5 beta2=0.75 eps=100, scalar x=2 / one update step with grad 100 / x becomes ~0.9803", func(t *testing.T) {
-			optimizer, err := optimizers.NewAdam(&optimizers.AdamConfig{
-				LearningRate: 2.,
-				WeightDecay:  2.,
-				Beta1:        0.5,
-				Beta2:        0.75,
-				Eps:          100.,
-			})
+		t.Run("Adam empty config (defaults), scalar x=1 / 2 consecutive update steps with grad 100 / x converges by 0.001 each step: 1→0.999→0.998", func(t *testing.T) {
+			optimizer, err := optimizers.NewAdam(&optimizers.AdamConfig{})
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			x, err := tensor.Full(nil, 2., &tensor.Config{
+			x, err := tensor.Full(nil, 1., &tensor.Config{
 				Device:    dev,
 				GradTrack: true,
 			})
@@ -294,6 +340,7 @@ func TestAdam(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			// step 1: x ≈ 0.999
 			y := x.Scale(4.).Scale(5.).Scale(5.)
 
 			err = tensor.BackPropagate(y)
@@ -305,11 +352,44 @@ func TestAdam(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			expl, err := tensor.Full(nil, 0.9803-1e-4, &tensor.Config{Device: dev})
+			expl, err := tensor.Full(nil, 0.999-1e-10, &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}
-			expu, err := tensor.Full(nil, 0.9803+1e-4, &tensor.Config{Device: dev})
+			expu, err := tensor.Full(nil, 0.999+1e-10, &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if p, err := x.Gt(expl); err != nil {
+				t.Fatal(err)
+			} else if p.Sum() < float64(p.NElems()) {
+				t.Fatal("expected output to be in range")
+			}
+			if p, err := x.Lt(expu); err != nil {
+				t.Fatal(err)
+			} else if p.Sum() < float64(p.NElems()) {
+				t.Fatal("expected output to be in range")
+			}
+
+			// step 2: x ≈ 0.998
+			x.ResetGradContext(true)
+			y = x.Scale(4.).Scale(5.).Scale(5.)
+
+			err = tensor.BackPropagate(y)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = optimizer.Update(&x)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			expl, err = tensor.Full(nil, 0.998-1e-10, &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+			expu, err = tensor.Full(nil, 0.998+1e-10, &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -327,15 +407,6 @@ func TestAdam(t *testing.T) {
 		})
 
 		// ============================== validations ==============================
-
-		t.Run("NewAdam with LearningRate=0 / returns error: non-positive LearningRate", func(t *testing.T) {
-			_, err := optimizers.NewAdam(&optimizers.AdamConfig{})
-			if err == nil {
-				t.Fatal("expected error because of non-positive 'LearningRate'")
-			} else if err.Error() != "Adam config data validation failed: expected 'LearningRate' to be positive: got (0.000000)" {
-				t.Fatal("unexpected error message returned")
-			}
-		})
 
 		t.Run("NewAdam with LearningRate=-1 / returns error: non-positive LearningRate", func(t *testing.T) {
 			_, err := optimizers.NewAdam(&optimizers.AdamConfig{
@@ -355,7 +426,7 @@ func TestAdam(t *testing.T) {
 			})
 			if err == nil {
 				t.Fatal("expected error because of negative 'WeightDecay'")
-			} else if err.Error() != "Adam config data validation failed: expected 'WeightDecay' not to be negative: got (-1.000000)" {
+			} else if err.Error() != "Adam config data validation failed: expected 'WeightDecay' to be positive: got (-1.000000)" {
 				t.Fatal("unexpected error message returned")
 			}
 		})
@@ -368,7 +439,7 @@ func TestAdam(t *testing.T) {
 			})
 			if err == nil {
 				t.Fatal("expected error because of negative 'Beta1'")
-			} else if err.Error() != "Adam config data validation failed: expected 'Beta1' not to be negative: got (-0.500000)" {
+			} else if err.Error() != "Adam config data validation failed: expected 'Beta1' to be positive: got (-0.500000)" {
 				t.Fatal("unexpected error message returned")
 			}
 		})
@@ -382,21 +453,7 @@ func TestAdam(t *testing.T) {
 			})
 			if err == nil {
 				t.Fatal("expected error because of negative 'Beta2'")
-			} else if err.Error() != "Adam config data validation failed: expected 'Beta2' not to be negative: got (-0.100000)" {
-				t.Fatal("unexpected error message returned")
-			}
-		})
-
-		t.Run("NewAdam with Eps=0 / returns error: non-positive Eps", func(t *testing.T) {
-			_, err := optimizers.NewAdam(&optimizers.AdamConfig{
-				LearningRate: 100,
-				WeightDecay:  10,
-				Beta1:        1,
-				Beta2:        0,
-			})
-			if err == nil {
-				t.Fatal("expected error because of non-positive 'Eps'")
-			} else if err.Error() != "Adam config data validation failed: expected 'Eps' to be positive: got (0.000000)" {
+			} else if err.Error() != "Adam config data validation failed: expected 'Beta2' to be positive: got (-0.100000)" {
 				t.Fatal("unexpected error message returned")
 			}
 		})

--- a/component/optimizers/adamw.go
+++ b/component/optimizers/adamw.go
@@ -160,7 +160,23 @@ func toValidAdamWConfig(iconf *AdamWConfig) (conf *AdamWConfig, err error) {
 	conf = new(AdamWConfig)
 	*conf = *iconf
 
-	if conf.LearningRate <= 0 {
+	if conf.LearningRate == 0. {
+		conf.LearningRate = AdamWDefaultLearningRate
+	}
+	if conf.WeightDecay == 0. {
+		conf.WeightDecay = AdamWDefaultWeightDecay
+	}
+	if conf.Beta1 == 0. {
+		conf.Beta1 = AdamWDefaultBeta1
+	}
+	if conf.Beta2 == 0. {
+		conf.Beta2 = AdamWDefaultBeta2
+	}
+	if conf.Eps == 0. {
+		conf.Eps = AdamWDefaultEps
+	}
+
+	if conf.LearningRate < 0 {
 		return conf, fmt.Errorf("expected 'LearningRate' to be positive: got (%f)", conf.LearningRate)
 	}
 
@@ -176,7 +192,7 @@ func toValidAdamWConfig(iconf *AdamWConfig) (conf *AdamWConfig, err error) {
 		return conf, fmt.Errorf("expected 'Beta2' not to be negative: got (%f)", conf.Beta2)
 	}
 
-	if conf.Eps <= 0 {
+	if conf.Eps < 0 {
 		return conf, fmt.Errorf("expected 'Eps' to be positive: got (%f)", conf.Eps)
 	}
 

--- a/component/optimizers/adamw.go
+++ b/component/optimizers/adamw.go
@@ -181,15 +181,15 @@ func toValidAdamWConfig(iconf *AdamWConfig) (conf *AdamWConfig, err error) {
 	}
 
 	if conf.WeightDecay < 0 {
-		return conf, fmt.Errorf("expected 'WeightDecay' not to be negative: got (%f)", conf.WeightDecay)
+		return conf, fmt.Errorf("expected 'WeightDecay' to be positive: got (%f)", conf.WeightDecay)
 	}
 
 	if conf.Beta1 < 0 {
-		return conf, fmt.Errorf("expected 'Beta1' not to be negative: got (%f)", conf.Beta1)
+		return conf, fmt.Errorf("expected 'Beta1' to be positive: got (%f)", conf.Beta1)
 	}
 
 	if conf.Beta2 < 0 {
-		return conf, fmt.Errorf("expected 'Beta2' not to be negative: got (%f)", conf.Beta2)
+		return conf, fmt.Errorf("expected 'Beta2' to be positive: got (%f)", conf.Beta2)
 	}
 
 	if conf.Eps < 0 {

--- a/component/optimizers/adamw_test.go
+++ b/component/optimizers/adamw_test.go
@@ -276,16 +276,87 @@ func TestAdamW(t *testing.T) {
 			}
 		})
 
-		// ============================== validations ==============================
+		t.Run("AdamW empty config (defaults), scalar x=1 / 2 consecutive update steps with grad 100 / x converges: ~0.99899→~0.99798", func(t *testing.T) {
+			optimizer, err := optimizers.NewAdamW(&optimizers.AdamWConfig{})
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		t.Run("NewAdamW with LearningRate=0 / returns error: non-positive LearningRate", func(t *testing.T) {
-			_, err := optimizers.NewAdamW(&optimizers.AdamWConfig{})
-			if err == nil {
-				t.Fatal("expected error because of non-positive 'LearningRate'")
-			} else if err.Error() != "AdamW config data validation failed: expected 'LearningRate' to be positive: got (0.000000)" {
-				t.Fatal("unexpected error message returned")
+			x, err := tensor.Full(nil, 1., &tensor.Config{
+				Device:    dev,
+				GradTrack: true,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// step 1: x ≈ 0.99899
+			y := x.Scale(4.).Scale(5.).Scale(5.)
+
+			err = tensor.BackPropagate(y)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = optimizer.Update(&x)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			expl, err := tensor.Full(nil, 0.99899-1e-5, &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+			expu, err := tensor.Full(nil, 0.99899+1e-5, &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if p, err := x.Gt(expl); err != nil {
+				t.Fatal(err)
+			} else if p.Sum() < float64(p.NElems()) {
+				t.Fatal("expected output to be in range")
+			}
+			if p, err := x.Lt(expu); err != nil {
+				t.Fatal(err)
+			} else if p.Sum() < float64(p.NElems()) {
+				t.Fatal("expected output to be in range")
+			}
+
+			// step 2: x ≈ 0.99798
+			x.ResetGradContext(true)
+			y = x.Scale(4.).Scale(5.).Scale(5.)
+
+			err = tensor.BackPropagate(y)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = optimizer.Update(&x)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			expl, err = tensor.Full(nil, 0.99798-1e-5, &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+			expu, err = tensor.Full(nil, 0.99798+1e-5, &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if p, err := x.Gt(expl); err != nil {
+				t.Fatal(err)
+			} else if p.Sum() < float64(p.NElems()) {
+				t.Fatal("expected output to be in range")
+			}
+			if p, err := x.Lt(expu); err != nil {
+				t.Fatal(err)
+			} else if p.Sum() < float64(p.NElems()) {
+				t.Fatal("expected output to be in range")
 			}
 		})
+
+		// ============================== validations ==============================
 
 		t.Run("NewAdamW with LearningRate=-1 / returns error: non-positive LearningRate", func(t *testing.T) {
 			_, err := optimizers.NewAdamW(&optimizers.AdamWConfig{
@@ -333,20 +404,6 @@ func TestAdamW(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected error because of negative 'Beta2'")
 			} else if err.Error() != "AdamW config data validation failed: expected 'Beta2' not to be negative: got (-0.100000)" {
-				t.Fatal("unexpected error message returned")
-			}
-		})
-
-		t.Run("NewAdamW with Eps=0 / returns error: non-positive Eps", func(t *testing.T) {
-			_, err := optimizers.NewAdamW(&optimizers.AdamWConfig{
-				LearningRate: 100,
-				WeightDecay:  10,
-				Beta1:        1,
-				Beta2:        0,
-			})
-			if err == nil {
-				t.Fatal("expected error because of non-positive 'Eps'")
-			} else if err.Error() != "AdamW config data validation failed: expected 'Eps' to be positive: got (0.000000)" {
 				t.Fatal("unexpected error message returned")
 			}
 		})

--- a/component/optimizers/adamw_test.go
+++ b/component/optimizers/adamw_test.go
@@ -376,7 +376,7 @@ func TestAdamW(t *testing.T) {
 			})
 			if err == nil {
 				t.Fatal("expected error because of negative 'WeightDecay'")
-			} else if err.Error() != "AdamW config data validation failed: expected 'WeightDecay' not to be negative: got (-1.000000)" {
+			} else if err.Error() != "AdamW config data validation failed: expected 'WeightDecay' to be positive: got (-1.000000)" {
 				t.Fatal("unexpected error message returned")
 			}
 		})
@@ -389,7 +389,7 @@ func TestAdamW(t *testing.T) {
 			})
 			if err == nil {
 				t.Fatal("expected error because of negative 'Beta1'")
-			} else if err.Error() != "AdamW config data validation failed: expected 'Beta1' not to be negative: got (-0.500000)" {
+			} else if err.Error() != "AdamW config data validation failed: expected 'Beta1' to be positive: got (-0.500000)" {
 				t.Fatal("unexpected error message returned")
 			}
 		})
@@ -403,7 +403,7 @@ func TestAdamW(t *testing.T) {
 			})
 			if err == nil {
 				t.Fatal("expected error because of negative 'Beta2'")
-			} else if err.Error() != "AdamW config data validation failed: expected 'Beta2' not to be negative: got (-0.100000)" {
+			} else if err.Error() != "AdamW config data validation failed: expected 'Beta2' to be positive: got (-0.100000)" {
 				t.Fatal("unexpected error message returned")
 			}
 		})

--- a/component/optimizers/sgd.go
+++ b/component/optimizers/sgd.go
@@ -116,7 +116,17 @@ func toValidSGDConfig(iconf *SGDConfig) (conf *SGDConfig, err error) {
 	conf = new(SGDConfig)
 	*conf = *iconf
 
-	if conf.LearningRate <= 0 {
+	if conf.LearningRate == 0. {
+		conf.LearningRate = SGDDefaultLearningRate
+	}
+	if conf.WeightDecay == 0. {
+		conf.WeightDecay = SGDDefaultWeightDecay
+	}
+	if conf.Momentum == 0. {
+		conf.Momentum = SGDDefaultMomentum
+	}
+
+	if conf.LearningRate < 0 {
 		return conf, fmt.Errorf("expected 'LearningRate' to be positive: got (%f)", conf.LearningRate)
 	}
 

--- a/component/optimizers/sgd.go
+++ b/component/optimizers/sgd.go
@@ -131,11 +131,11 @@ func toValidSGDConfig(iconf *SGDConfig) (conf *SGDConfig, err error) {
 	}
 
 	if conf.WeightDecay < 0 {
-		return conf, fmt.Errorf("expected 'WeightDecay' not to be negative: got (%f)", conf.WeightDecay)
+		return conf, fmt.Errorf("expected 'WeightDecay' to be positive: got (%f)", conf.WeightDecay)
 	}
 
 	if conf.Momentum < 0 {
-		return conf, fmt.Errorf("expected 'Momentum' not to be negative: got (%f)", conf.Momentum)
+		return conf, fmt.Errorf("expected 'Momentum' to be positive: got (%f)", conf.Momentum)
 	}
 
 	return conf, nil

--- a/component/optimizers/sgd_test.go
+++ b/component/optimizers/sgd_test.go
@@ -413,7 +413,7 @@ func TestSGD(t *testing.T) {
 			})
 			if err == nil {
 				t.Fatal("expected error because of negative 'WeightDecay'")
-			} else if err.Error() != "SGD config data validation failed: expected 'WeightDecay' not to be negative: got (-1.000000)" {
+			} else if err.Error() != "SGD config data validation failed: expected 'WeightDecay' to be positive: got (-1.000000)" {
 				t.Fatal("unexpected error message returned")
 			}
 		})
@@ -426,7 +426,7 @@ func TestSGD(t *testing.T) {
 			})
 			if err == nil {
 				t.Fatal("expected error because of negative 'Momentum'")
-			} else if err.Error() != "SGD config data validation failed: expected 'Momentum' not to be negative: got (-0.500000)" {
+			} else if err.Error() != "SGD config data validation failed: expected 'Momentum' to be positive: got (-0.500000)" {
 				t.Fatal("unexpected error message returned")
 			}
 		})

--- a/component/optimizers/sgd_test.go
+++ b/component/optimizers/sgd_test.go
@@ -269,16 +269,131 @@ func TestSGD(t *testing.T) {
 			}
 		})
 
-		// ============================== validations ==============================
+		t.Run("SGD nil config (default initialization: lr=0.01, momentum=0), scalar x=1 / step 1: gradient 100, x becomes 0 / step 2: gradient 50, x becomes -0.5 (no momentum accumulation)", func(t *testing.T) {
+			optimizer, err := optimizers.NewSGD(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
 
-		t.Run("NewSGD with LearningRate=0 / returns error: non-positive LearningRate", func(t *testing.T) {
-			_, err := optimizers.NewSGD(&optimizers.SGDConfig{})
-			if err == nil {
-				t.Fatal("expected error because of non-positive 'LearningRate'")
-			} else if err.Error() != "SGD config data validation failed: expected 'LearningRate' to be positive: got (0.000000)" {
-				t.Fatal("unexpected error message returned")
+			x, err := tensor.Full(nil, 1., &tensor.Config{
+				Device:    dev,
+				GradTrack: true,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// step 1: default lr=0.01, grad=100, x = 1 - 0.01*100 = 0
+			y := x.Scale(4.).Scale(5.).Scale(5.)
+
+			err = tensor.BackPropagate(y)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = optimizer.Update(&x)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Full(nil, 0., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := x.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal after step 1")
+			}
+
+			// step 2: default momentum=0, grad=50, no velocity accumulation, x = 0 - 0.01*50 = -0.5
+			x.ResetGradContext(true)
+			y = x.Scale(2.).Scale(5.).Scale(5.)
+
+			err = tensor.BackPropagate(y)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = optimizer.Update(&x)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err = tensor.Full(nil, -0.5, &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := x.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal after step 2")
 			}
 		})
+
+		t.Run("SGD empty config (default initialization: lr=0.01, momentum=0), scalar x=2 / step 1: gradient 50, x becomes 1.5 / step 2: gradient 50, x becomes 1.0 (no momentum accumulation)", func(t *testing.T) {
+			optimizer, err := optimizers.NewSGD(&optimizers.SGDConfig{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			x, err := tensor.Full(nil, 2., &tensor.Config{
+				Device:    dev,
+				GradTrack: true,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// step 1: default lr=0.01, grad=50, x = 2 - 0.01*50 = 1.5
+			y := x.Scale(2.).Scale(5.).Scale(5.)
+
+			err = tensor.BackPropagate(y)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = optimizer.Update(&x)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Full(nil, 1.5, &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := x.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal after step 1")
+			}
+
+			// step 2: default momentum=0, grad=50, no velocity accumulation, x = 1.5 - 0.01*50 = 1.0
+			x.ResetGradContext(true)
+			y = x.Scale(2.).Scale(5.).Scale(5.)
+
+			err = tensor.BackPropagate(y)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = optimizer.Update(&x)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err = tensor.Full(nil, 1.0, &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := x.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal after step 2")
+			}
+		})
+
+		// ============================== validations ==============================
 
 		t.Run("NewSGD with LearningRate=-1 / returns error: non-positive LearningRate", func(t *testing.T) {
 			_, err := optimizers.NewSGD(&optimizers.SGDConfig{

--- a/examples/01-boston-housing/main.go
+++ b/examples/01-boston-housing/main.go
@@ -36,7 +36,7 @@ func main() {
 		fmt.Printf("%s: %.2f\n", m, r)
 	}
 
-	// Best Mean Squared Error (MSE): 75.83
+	// Best Mean Squared Error (MSE): 73.03
 }
 
 func run() (result map[string]float64, err error) {
@@ -77,29 +77,17 @@ func prepareModel() (m *model.Model, err error) {
 
 	x := stream.FC(&layers.FCConfig{Outputs: 128, Device: dev})(input)
 	x = stream.Relu()(x)
-	x = stream.BatchNorm(&layers.BatchNormConfig{
-		Momentum: layers.BatchNormDefaultMomentum,
-		Eps:      layers.BatchNormDefaultEps,
-		Device:   dev,
-	})(x)
+	x = stream.BatchNorm(&layers.BatchNormConfig{Device: dev})(x)
 	x = stream.Dropout(&layers.DropoutConfig{Rate: 0.2})(x)
 
 	x = stream.FC(&layers.FCConfig{Outputs: 64, Device: dev})(x)
 	x = stream.Relu()(x)
-	x = stream.BatchNorm(&layers.BatchNormConfig{
-		Momentum: layers.BatchNormDefaultMomentum,
-		Eps:      layers.BatchNormDefaultEps,
-		Device:   dev,
-	})(x)
+	x = stream.BatchNorm(&layers.BatchNormConfig{Device: dev})(x)
 	x = stream.Dropout(&layers.DropoutConfig{Rate: 0.2})(x)
 
 	x = stream.FC(&layers.FCConfig{Outputs: 32, Device: dev})(x)
 	x = stream.Relu()(x)
-	x = stream.BatchNorm(&layers.BatchNormConfig{
-		Momentum: layers.BatchNormDefaultMomentum,
-		Eps:      layers.BatchNormDefaultEps,
-		Device:   dev,
-	})(x)
+	x = stream.BatchNorm(&layers.BatchNormConfig{Device: dev})(x)
 	x = stream.Dropout(&layers.DropoutConfig{Rate: 0.2})(x)
 
 	output := stream.FC(&layers.FCConfig{Outputs: 1, Device: dev})(x)

--- a/examples/02-breast-cancer/main.go
+++ b/examples/02-breast-cancer/main.go
@@ -36,7 +36,7 @@ func main() {
 		fmt.Printf("%s: %.2f\n", m, r)
 	}
 
-	// Best Accuracy: 0.47
+	// Best Accuracy: 0.50
 }
 
 func run() (result map[string]float64, err error) {

--- a/examples/02-breast-cancer/main.go
+++ b/examples/02-breast-cancer/main.go
@@ -77,20 +77,12 @@ func prepareModel() (m *model.Model, err error) {
 
 	x := stream.FC(&layers.FCConfig{Outputs: 64, Device: dev})(input)
 	x = stream.Relu()(x)
-	x = stream.BatchNorm(&layers.BatchNormConfig{
-		Momentum: layers.BatchNormDefaultMomentum,
-		Eps:      layers.BatchNormDefaultEps,
-		Device:   dev,
-	})(x)
+	x = stream.BatchNorm(&layers.BatchNormConfig{Device: dev})(x)
 	x = stream.Dropout(&layers.DropoutConfig{Rate: 0.3})(x)
 
 	x = stream.FC(&layers.FCConfig{Outputs: 32, Device: dev})(x)
 	x = stream.Relu()(x)
-	x = stream.BatchNorm(&layers.BatchNormConfig{
-		Momentum: layers.BatchNormDefaultMomentum,
-		Eps:      layers.BatchNormDefaultEps,
-		Device:   dev,
-	})(x)
+	x = stream.BatchNorm(&layers.BatchNormConfig{Device: dev})(x)
 	x = stream.Dropout(&layers.DropoutConfig{Rate: 0.3})(x)
 
 	x = stream.FC(&layers.FCConfig{Outputs: 1, Device: dev})(x)
@@ -100,13 +92,7 @@ func prepareModel() (m *model.Model, err error) {
 
 	loss := losses.NewBCE()
 
-	optimizer, err := optimizers.NewAdamW(&optimizers.AdamWConfig{
-		LearningRate: optimizers.AdamWDefaultLearningRate,
-		WeightDecay:  1e-4,
-		Beta1:        optimizers.AdamWDefaultBeta1,
-		Beta2:        optimizers.AdamWDefaultBeta2,
-		Eps:          optimizers.AdamWDefaultEps,
-	})
+	optimizer, err := optimizers.NewAdamW(&optimizers.AdamWConfig{WeightDecay: 1e-4})
 	if err != nil {
 		return m, err
 	}

--- a/examples/03-Iris/main.go
+++ b/examples/03-Iris/main.go
@@ -95,13 +95,7 @@ func prepareModel() (m *model.Model, err error) {
 
 	loss := losses.NewCE()
 
-	optimizer, err := optimizers.NewAdamW(&optimizers.AdamWConfig{
-		LearningRate: optimizers.AdamWDefaultLearningRate,
-		WeightDecay:  1e-4,
-		Beta1:        optimizers.AdamWDefaultBeta1,
-		Beta2:        optimizers.AdamWDefaultBeta2,
-		Eps:          optimizers.AdamWDefaultEps,
-	})
+	optimizer, err := optimizers.NewAdam(&optimizers.AdamConfig{WeightDecay: 1e-4})
 	if err != nil {
 		return m, err
 	}

--- a/model/batchgens/simple.go
+++ b/model/batchgens/simple.go
@@ -120,12 +120,12 @@ func toValidSimpleConfig(iconf *SimpleConfig) (conf *SimpleConfig, err error) {
 	conf = new(SimpleConfig)
 	*conf = *iconf
 
-	if conf.BatchSize <= 0 {
-		return conf, fmt.Errorf("expected 'BatchSize' to be positive: got (%d)", conf.BatchSize)
-	}
-
 	if conf.Device == 0 {
 		conf.Device = tensor.CPU
+	}
+
+	if conf.BatchSize <= 0 {
+		return conf, fmt.Errorf("expected 'BatchSize' to be positive: got (%d)", conf.BatchSize)
 	}
 
 	return conf, nil

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -619,7 +619,7 @@ func TestModel(t *testing.T) {
 
 		t.Run("Fit with nil config / returns error: Fit config not to be nil", func(t *testing.T) {
 			input := stream.Input()
-			output := stream.Softmax(nil)(input)
+			output := stream.Softmax(&activations.SoftmaxConfig{Dim: 0})(input)
 			m, err := model.NewMultiInputModel([]*stream.Stream{input}, output, new(model.ModelConfig))
 			if err != nil {
 				t.Fatal(err)
@@ -635,7 +635,7 @@ func TestModel(t *testing.T) {
 
 		t.Run("Fit with 0 epochs / returns error: Epochs to be positive", func(t *testing.T) {
 			input := stream.Input()
-			output := stream.Softmax(nil)(input)
+			output := stream.Softmax(&activations.SoftmaxConfig{Dim: 0})(input)
 			m, err := model.NewMultiInputModel([]*stream.Stream{input}, output, new(model.ModelConfig))
 			if err != nil {
 				t.Fatal(err)
@@ -651,7 +651,7 @@ func TestModel(t *testing.T) {
 
 		t.Run("Predict with 2 inputs for 1-input model / returns error: expected exactly 1 input tensor", func(t *testing.T) {
 			input := stream.Input()
-			output := stream.Softmax(nil)(input)
+			output := stream.Softmax(&activations.SoftmaxConfig{Dim: 0})(input)
 			m, err := model.NewMultiInputModel([]*stream.Stream{input}, output, new(model.ModelConfig))
 			if err != nil {
 				t.Fatal(err)

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -619,7 +619,7 @@ func TestModel(t *testing.T) {
 
 		t.Run("Fit with nil config / returns error: Fit config not to be nil", func(t *testing.T) {
 			input := stream.Input()
-			output := stream.Softmax(&activations.SoftmaxConfig{Dim: 0})(input)
+			output := stream.Softmax(&activations.SoftmaxConfig{Dim: 1})(input)
 			m, err := model.NewMultiInputModel([]*stream.Stream{input}, output, new(model.ModelConfig))
 			if err != nil {
 				t.Fatal(err)
@@ -635,7 +635,7 @@ func TestModel(t *testing.T) {
 
 		t.Run("Fit with 0 epochs / returns error: Epochs to be positive", func(t *testing.T) {
 			input := stream.Input()
-			output := stream.Softmax(&activations.SoftmaxConfig{Dim: 0})(input)
+			output := stream.Softmax(&activations.SoftmaxConfig{Dim: 1})(input)
 			m, err := model.NewMultiInputModel([]*stream.Stream{input}, output, new(model.ModelConfig))
 			if err != nil {
 				t.Fatal(err)
@@ -651,7 +651,7 @@ func TestModel(t *testing.T) {
 
 		t.Run("Predict with 2 inputs for 1-input model / returns error: expected exactly 1 input tensor", func(t *testing.T) {
 			input := stream.Input()
-			output := stream.Softmax(&activations.SoftmaxConfig{Dim: 0})(input)
+			output := stream.Softmax(&activations.SoftmaxConfig{Dim: 1})(input)
 			m, err := model.NewMultiInputModel([]*stream.Stream{input}, output, new(model.ModelConfig))
 			if err != nil {
 				t.Fatal(err)

--- a/model/stream/built_in_layers_test.go
+++ b/model/stream/built_in_layers_test.go
@@ -78,7 +78,7 @@ func TestBuiltInLayers(t *testing.T) {
 
 		t.Run("BatchNorm(valid config) / applying to stream / no error", func(t *testing.T) {
 			x := stream.Input()
-			x = stream.BatchNorm(&layers.BatchNormConfig{Momentum: 0.99, Eps: 1e-3})(x)
+			x = stream.BatchNorm(nil)(x)
 
 			if err := x.Error(); err != nil {
 				t.Fatal(err)

--- a/model/stream/built_in_layers_test.go
+++ b/model/stream/built_in_layers_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/sahandsafizadeh/qeep/component/layers"
+	"github.com/sahandsafizadeh/qeep/component/layers/activations"
 	"github.com/sahandsafizadeh/qeep/model/stream"
 	"github.com/sahandsafizadeh/qeep/tensor"
 )
@@ -41,7 +42,7 @@ func TestBuiltInLayers(t *testing.T) {
 
 		t.Run("Softmax(nil) / applying to stream with nil config / no error", func(t *testing.T) {
 			x := stream.Input()
-			x = stream.Softmax(nil)(x)
+			x = stream.Softmax(&activations.SoftmaxConfig{Dim: 1})(x)
 
 			if err := x.Error(); err != nil {
 				t.Fatal(err)

--- a/model/stream/stream_test.go
+++ b/model/stream/stream_test.go
@@ -21,7 +21,7 @@ func TestStream(t *testing.T) {
 			fc1 := stream.FC(&layers.FCConfig{Outputs: 4})(input)
 			tanh := stream.Tanh()(fc1)
 			fc2 := stream.FC(&layers.FCConfig{Outputs: 2})(tanh)
-			output := stream.Softmax(nil)(fc2)
+			output := stream.Softmax(&activations.SoftmaxConfig{Dim: 1})(fc2)
 
 			if err := input.Error(); err != nil {
 				t.Fatal(err)

--- a/tensor/tensor_test/forward_test/initializers_test.go
+++ b/tensor/tensor_test/forward_test/initializers_test.go
@@ -13,6 +13,20 @@ func TestZeros(t *testing.T) {
 
 		// ============================== main paths ==============================
 
+		t.Run("Zeros(nil config) / Device() and GradientTracked() / returns CPU and false", func(t *testing.T) {
+			ten, err := tensor.Zeros(nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if d := ten.Device(); d != tensor.CPU {
+				t.Fatalf("expected tensor's device to be (%s), got (%s)", tensor.CPU, d)
+			}
+			if ten.GradientTracked() {
+				t.Fatal("expected tensor to not be gradient tracked")
+			}
+		})
+
 		t.Run("Zeros(nil) scalar / Equals Full(nil, 0.) / returns true", func(t *testing.T) {
 			act, err := tensor.Zeros(nil, &tensor.Config{Device: dev})
 			if err != nil {
@@ -166,6 +180,20 @@ func TestOnes(t *testing.T) {
 
 		// ============================== main paths ==============================
 
+		t.Run("Ones(nil config) / Device() and GradientTracked() / returns CPU and false", func(t *testing.T) {
+			ten, err := tensor.Ones(nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if d := ten.Device(); d != tensor.CPU {
+				t.Fatalf("expected tensor's device to be (%s), got (%s)", tensor.CPU, d)
+			}
+			if ten.GradientTracked() {
+				t.Fatal("expected tensor to not be gradient tracked")
+			}
+		})
+
 		t.Run("Ones(nil) scalar / Equals Full(nil, 1.) / returns true", func(t *testing.T) {
 			act, err := tensor.Ones(nil, &tensor.Config{Device: dev})
 			if err != nil {
@@ -318,6 +346,20 @@ func TestEye(t *testing.T) {
 
 	// ============================== main paths ==============================
 
+	t.Run("Eye(nil config) / Device() and GradientTracked() / returns CPU and false", func(t *testing.T) {
+		ten, err := tensor.Eye(1, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if d := ten.Device(); d != tensor.CPU {
+			t.Fatalf("expected tensor's device to be (%s), got (%s)", tensor.CPU, d)
+		}
+		if ten.GradientTracked() {
+			t.Fatal("expected tensor to not be gradient tracked")
+		}
+	})
+
 	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
 		t.Run("Eye(1) 1x1 identity matrix / Equals / returns true", func(t *testing.T) {
 			act, err := tensor.Eye(1, &tensor.Config{Device: dev})
@@ -395,6 +437,22 @@ func TestEye(t *testing.T) {
 func TestRandU(t *testing.T) {
 	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
 
+		// ============================== main paths ==============================
+
+		t.Run("RandU(nil config) / Device() and GradientTracked() / returns CPU and false", func(t *testing.T) {
+			ten, err := tensor.RandU(nil, 0., 1., nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if d := ten.Device(); d != tensor.CPU {
+				t.Fatalf("expected tensor's device to be (%s), got (%s)", tensor.CPU, d)
+			}
+			if ten.GradientTracked() {
+				t.Fatal("expected tensor to not be gradient tracked")
+			}
+		})
+
 		// ============================== side effects ==============================
 
 		t.Run("RandU([3,4], -1, 1) does not share dims slice / Shape() after mutating dims / returns [3,4]", func(t *testing.T) {
@@ -462,6 +520,22 @@ func TestRandU(t *testing.T) {
 
 func TestRandN(t *testing.T) {
 	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
+
+		// ============================== main paths ==============================
+
+		t.Run("RandN(nil config) / Device() and GradientTracked() / returns CPU and false", func(t *testing.T) {
+			ten, err := tensor.RandN(nil, 0., 1., nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if d := ten.Device(); d != tensor.CPU {
+				t.Fatalf("expected tensor's device to be (%s), got (%s)", tensor.CPU, d)
+			}
+			if ten.GradientTracked() {
+				t.Fatal("expected tensor to not be gradient tracked")
+			}
+		})
 
 		// ============================== side effects ==============================
 

--- a/tensor/tensor_test/forward_test/primary_ops_test.go
+++ b/tensor/tensor_test/forward_test/primary_ops_test.go
@@ -22,6 +22,20 @@ func TestFullAt(t *testing.T) {
 
 		// ============================== main paths ==============================
 
+		t.Run("Full(nil, 0) with nil config / Device() and GradientTracked() / returns CPU and false", func(t *testing.T) {
+			ten, err := tensor.Full(nil, 0., nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if d := ten.Device(); d != tensor.CPU {
+				t.Fatalf("expected tensor's device to be (%s), got (%s)", tensor.CPU, d)
+			}
+			if ten.GradientTracked() {
+				t.Fatal("expected tensor to not be gradient tracked")
+			}
+		})
+
 		t.Run("Full(nil, -1) scalar tensor / At() with no indices / returns -1", func(t *testing.T) {
 			ten, err := tensor.Full(nil, -1., &tensor.Config{Device: dev})
 			if err != nil {
@@ -296,6 +310,20 @@ func TestOfAt(t *testing.T) {
 	tensor.RunTestLogicOnDevices(func(dev tensor.Device) {
 
 		// ============================== main paths ==============================
+
+		t.Run("Of(nil config) / Device() and GradientTracked() / returns CPU and false", func(t *testing.T) {
+			ten, err := tensor.Of(0., nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if d := ten.Device(); d != tensor.CPU {
+				t.Fatalf("expected tensor's device to be (%s), got (%s)", tensor.CPU, d)
+			}
+			if ten.GradientTracked() {
+				t.Fatal("expected tensor to not be gradient tracked")
+			}
+		})
 
 		t.Run("Of(2) scalar / At() / returns 2", func(t *testing.T) {
 			ten, err := tensor.Of(2., &tensor.Config{Device: dev})


### PR DESCRIPTION
1. **Feat**: Simplify usage by placing default values for _zero values_.
- Now for optimizers (`SGD`, `Adam` and `AdamW`) and `BatchNorm` layer, user can specify the hyper-parameters they need and the rest will be filled by default values. This way, while code is cleaner, component still continues to use its best settings.
- This is done where _zero value_ (mostly `0.` for `float64`) has no meaning. For instance, `Softmax` activation is changed to not have any initialization facility!
- Examples are updated following this changes.

2. **Fix**: remove broken `gosec` tool from `Makefile`.