### PR TITLE
fix(tensor): split Eq and Equals accuracy

### DIFF
--- a/component/layers/activations/sigmoid_test.go
+++ b/component/layers/activations/sigmoid_test.go
@@ -26,24 +26,15 @@ func TestSigmoid(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			expl, err := tensor.Of(-1e-10, &tensor.Config{Device: dev})
-			if err != nil {
-				t.Fatal(err)
-			}
-			expu, err := tensor.Of(1e-10, &tensor.Config{Device: dev})
+			exp, err := tensor.Of(0., &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if p, err := act.Gt(expl); err != nil {
+			if eq, err := act.Equals(exp); err != nil {
 				t.Fatal(err)
-			} else if p.Sum() < float64(p.NElems()) {
-				t.Fatal("expected output to be in range")
-			}
-			if p, err := act.Lt(expu); err != nil {
-				t.Fatal(err)
-			} else if p.Sum() < float64(p.NElems()) {
-				t.Fatal("expected output to be in range")
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -60,24 +51,15 @@ func TestSigmoid(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			expl, err := tensor.Of(1.-1e-10, &tensor.Config{Device: dev})
-			if err != nil {
-				t.Fatal(err)
-			}
-			expu, err := tensor.Of(1.+1e-10, &tensor.Config{Device: dev})
+			exp, err := tensor.Of(1., &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if p, err := act.Gt(expl); err != nil {
+			if eq, err := act.Equals(exp); err != nil {
 				t.Fatal(err)
-			} else if p.Sum() < float64(p.NElems()) {
-				t.Fatal("expected output to be in range")
-			}
-			if p, err := act.Lt(expu); err != nil {
-				t.Fatal(err)
-			} else if p.Sum() < float64(p.NElems()) {
-				t.Fatal("expected output to be in range")
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -94,26 +76,15 @@ func TestSigmoid(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			c := 1. / (1 + (1. / math.E))
-
-			expl, err := tensor.Of(c-1e-10, &tensor.Config{Device: dev})
-			if err != nil {
-				t.Fatal(err)
-			}
-			expu, err := tensor.Of(c+1e-10, &tensor.Config{Device: dev})
+			exp, err := tensor.Of(1./(1+(1./math.E)), &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if p, err := act.Gt(expl); err != nil {
+			if eq, err := act.Equals(exp); err != nil {
 				t.Fatal(err)
-			} else if p.Sum() < float64(p.NElems()) {
-				t.Fatal("expected output to be in range")
-			}
-			if p, err := act.Lt(expu); err != nil {
-				t.Fatal(err)
-			} else if p.Sum() < float64(p.NElems()) {
-				t.Fatal("expected output to be in range")
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -134,7 +105,7 @@ func TestSigmoid(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			expu, err := tensor.Of(1e-240, &tensor.Config{Device: dev})
+			expu, err := tensor.Of(1e-300, &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/component/layers/activations/tanh_test.go
+++ b/component/layers/activations/tanh_test.go
@@ -26,26 +26,15 @@ func TestTanh(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			c := (math.E*math.E - 1) / (math.E*math.E + 1)
-
-			expl, err := tensor.Of(c-1e-10, &tensor.Config{Device: dev})
-			if err != nil {
-				t.Fatal(err)
-			}
-			expu, err := tensor.Of(c+1e-10, &tensor.Config{Device: dev})
+			exp, err := tensor.Of((math.E*math.E-1)/(math.E*math.E+1), &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if p, err := act.Gt(expl); err != nil {
+			if eq, err := act.Equals(exp); err != nil {
 				t.Fatal(err)
-			} else if p.Sum() < float64(p.NElems()) {
-				t.Fatal("expected output to be in range")
-			}
-			if p, err := act.Lt(expu); err != nil {
-				t.Fatal(err)
-			} else if p.Sum() < float64(p.NElems()) {
-				t.Fatal("expected output to be in range")
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 

--- a/component/losses/bce_test.go
+++ b/component/losses/bce_test.go
@@ -29,24 +29,15 @@ func TestBCE(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			expl, err := tensor.Of(0.-1e-10, &tensor.Config{Device: dev})
-			if err != nil {
-				t.Fatal(err)
-			}
-			expu, err := tensor.Of(0.+1e-10, &tensor.Config{Device: dev})
+			exp, err := tensor.Of(0., &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if p, err := act.Gt(expl); err != nil {
+			if eq, err := act.Equals(exp); err != nil {
 				t.Fatal(err)
-			} else if p.Sum() < float64(p.NElems()) {
-				t.Fatal("expected output to be in range")
-			}
-			if p, err := act.Lt(expu); err != nil {
-				t.Fatal(err)
-			} else if p.Sum() < float64(p.NElems()) {
-				t.Fatal("expected output to be in range")
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -67,24 +58,15 @@ func TestBCE(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			expl, err := tensor.Of(0.-1e-10, &tensor.Config{Device: dev})
-			if err != nil {
-				t.Fatal(err)
-			}
-			expu, err := tensor.Of(0.+1e-10, &tensor.Config{Device: dev})
+			exp, err := tensor.Of(0., &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if p, err := act.Gt(expl); err != nil {
+			if eq, err := act.Equals(exp); err != nil {
 				t.Fatal(err)
-			} else if p.Sum() < float64(p.NElems()) {
-				t.Fatal("expected output to be in range")
-			}
-			if p, err := act.Lt(expu); err != nil {
-				t.Fatal(err)
-			} else if p.Sum() < float64(p.NElems()) {
-				t.Fatal("expected output to be in range")
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 

--- a/component/losses/ce_test.go
+++ b/component/losses/ce_test.go
@@ -29,24 +29,15 @@ func TestCE(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			expl, err := tensor.Of(0.-1e-10, &tensor.Config{Device: dev})
-			if err != nil {
-				t.Fatal(err)
-			}
-			expu, err := tensor.Of(0.+1e-10, &tensor.Config{Device: dev})
+			exp, err := tensor.Of(0., &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if p, err := act.Gt(expl); err != nil {
+			if eq, err := act.Equals(exp); err != nil {
 				t.Fatal(err)
-			} else if p.Sum() < float64(p.NElems()) {
-				t.Fatal("expected output to be in range")
-			}
-			if p, err := act.Lt(expu); err != nil {
-				t.Fatal(err)
-			} else if p.Sum() < float64(p.NElems()) {
-				t.Fatal("expected output to be in range")
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -67,24 +58,15 @@ func TestCE(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			expl, err := tensor.Of(0.-1e-10, &tensor.Config{Device: dev})
-			if err != nil {
-				t.Fatal(err)
-			}
-			expu, err := tensor.Of(0.+1e-10, &tensor.Config{Device: dev})
+			exp, err := tensor.Of(0., &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if p, err := act.Gt(expl); err != nil {
+			if eq, err := act.Equals(exp); err != nil {
 				t.Fatal(err)
-			} else if p.Sum() < float64(p.NElems()) {
-				t.Fatal("expected output to be in range")
-			}
-			if p, err := act.Lt(expu); err != nil {
-				t.Fatal(err)
-			} else if p.Sum() < float64(p.NElems()) {
-				t.Fatal("expected output to be in range")
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 

--- a/component/metrics/accuracy_test.go
+++ b/component/metrics/accuracy_test.go
@@ -39,9 +39,8 @@ func TestAccuracy(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			result := metric.Result()
-			if !(1-1e-5 < result && result < 1+1e-5) {
-				t.Fatalf("expected result to be (1): got (%f)", result)
+			if res := metric.Result(); res != 1. {
+				t.Fatalf("expected result to be (1): got (%f)", res)
 			}
 		})
 
@@ -76,9 +75,8 @@ func TestAccuracy(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			result := metric.Result()
-			if !(0.6-1e-5 < result && result < 0.6+1e-5) {
-				t.Fatalf("expected result to be (0.6): got (%f)", result)
+			if res := metric.Result(); res != 0.6 {
+				t.Fatalf("expected result to be (0.6): got (%f)", res)
 			}
 		})
 
@@ -113,9 +111,8 @@ func TestAccuracy(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			result := metric.Result()
-			if !(1-1e-5 < result && result < 1+1e-5) {
-				t.Fatalf("expected result to be (1): got (%f)", result)
+			if res := metric.Result(); res != 1. {
+				t.Fatalf("expected result to be (1): got (%f)", res)
 			}
 		})
 
@@ -162,9 +159,8 @@ func TestAccuracy(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			result := metric.Result()
-			if !(0.5-1e-5 < result && result < 0.5+1e-5) {
-				t.Fatalf("expected result to be (0.5): got (%f)", result)
+			if res := metric.Result(); res != 0.5 {
+				t.Fatalf("expected result to be (0.5): got (%f)", res)
 			}
 		})
 
@@ -235,9 +231,8 @@ func TestAccuracy(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			result := metric.Result()
-			if !(0.375-1e-5 < result && result < 0.375+1e-5) {
-				t.Fatalf("expected result to be (0.375): got (%f)", result)
+			if res := metric.Result(); res != 0.375 {
+				t.Fatalf("expected result to be (0.375): got (%f)", res)
 			}
 		})
 

--- a/component/metrics/accuracy_test.go
+++ b/component/metrics/accuracy_test.go
@@ -40,7 +40,7 @@ func TestAccuracy(t *testing.T) {
 			}
 
 			result := metric.Result()
-			if !(1-1e-12 < result && result < 1+1e-12) {
+			if !(1-1e-5 < result && result < 1+1e-5) {
 				t.Fatalf("expected result to be (1): got (%f)", result)
 			}
 		})
@@ -77,7 +77,7 @@ func TestAccuracy(t *testing.T) {
 			}
 
 			result := metric.Result()
-			if !(0.6-1e-12 < result && result < 0.6+1e-12) {
+			if !(0.6-1e-5 < result && result < 0.6+1e-5) {
 				t.Fatalf("expected result to be (0.6): got (%f)", result)
 			}
 		})
@@ -114,7 +114,7 @@ func TestAccuracy(t *testing.T) {
 			}
 
 			result := metric.Result()
-			if !(1-1e-12 < result && result < 1+1e-12) {
+			if !(1-1e-5 < result && result < 1+1e-5) {
 				t.Fatalf("expected result to be (1): got (%f)", result)
 			}
 		})
@@ -163,7 +163,7 @@ func TestAccuracy(t *testing.T) {
 			}
 
 			result := metric.Result()
-			if !(0.5-1e-12 < result && result < 0.5+1e-12) {
+			if !(0.5-1e-5 < result && result < 0.5+1e-5) {
 				t.Fatalf("expected result to be (0.5): got (%f)", result)
 			}
 		})
@@ -236,7 +236,7 @@ func TestAccuracy(t *testing.T) {
 			}
 
 			result := metric.Result()
-			if !(0.375-1e-12 < result && result < 0.375+1e-12) {
+			if !(0.375-1e-5 < result && result < 0.375+1e-5) {
 				t.Fatalf("expected result to be (0.375): got (%f)", result)
 			}
 		})

--- a/component/metrics/accuracy_test.go
+++ b/component/metrics/accuracy_test.go
@@ -39,8 +39,7 @@ func TestAccuracy(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			result := metric.Result()
-			if !(1-1e-10 < result && result < 1+1e-10) {
+			if result := metric.Result(); result != 1. {
 				t.Fatalf("expected result to be (1): got (%f)", result)
 			}
 		})
@@ -76,8 +75,7 @@ func TestAccuracy(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			result := metric.Result()
-			if !(0.6-1e-10 < result && result < 0.6+1e-10) {
+			if result := metric.Result(); result != 0.6 {
 				t.Fatalf("expected result to be (0.6): got (%f)", result)
 			}
 		})
@@ -113,9 +111,7 @@ func TestAccuracy(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			result := metric.Result()
-
-			if !(1-1e-10 < result && result < 1+1e-10) {
+			if result := metric.Result(); result != 1. {
 				t.Fatalf("expected result to be (1): got (%f)", result)
 			}
 		})
@@ -163,8 +159,7 @@ func TestAccuracy(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			result := metric.Result()
-			if !(0.5-1e-10 < result && result < 0.5+1e-10) {
+			if result := metric.Result(); result != 0.5 {
 				t.Fatalf("expected result to be (0.5): got (%f)", result)
 			}
 		})
@@ -236,8 +231,7 @@ func TestAccuracy(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			result := metric.Result()
-			if !(0.375-1e-10 < result && result < 0.375+1e-10) {
+			if result := metric.Result(); result != 0.375 {
 				t.Fatalf("expected result to be (0.375): got (%f)", result)
 			}
 		})

--- a/component/metrics/accuracy_test.go
+++ b/component/metrics/accuracy_test.go
@@ -39,7 +39,8 @@ func TestAccuracy(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if result := metric.Result(); result != 1. {
+			result := metric.Result()
+			if !(1-1e-12 < result && result < 1+1e-12) {
 				t.Fatalf("expected result to be (1): got (%f)", result)
 			}
 		})
@@ -75,7 +76,8 @@ func TestAccuracy(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if result := metric.Result(); result != 0.6 {
+			result := metric.Result()
+			if !(0.6-1e-12 < result && result < 0.6+1e-12) {
 				t.Fatalf("expected result to be (0.6): got (%f)", result)
 			}
 		})
@@ -111,7 +113,8 @@ func TestAccuracy(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if result := metric.Result(); result != 1. {
+			result := metric.Result()
+			if !(1-1e-12 < result && result < 1+1e-12) {
 				t.Fatalf("expected result to be (1): got (%f)", result)
 			}
 		})
@@ -159,7 +162,8 @@ func TestAccuracy(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if result := metric.Result(); result != 0.5 {
+			result := metric.Result()
+			if !(0.5-1e-12 < result && result < 0.5+1e-12) {
 				t.Fatalf("expected result to be (0.5): got (%f)", result)
 			}
 		})
@@ -231,7 +235,8 @@ func TestAccuracy(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if result := metric.Result(); result != 0.375 {
+			result := metric.Result()
+			if !(0.375-1e-12 < result && result < 0.375+1e-12) {
 				t.Fatalf("expected result to be (0.375): got (%f)", result)
 			}
 		})

--- a/component/metrics/mse_test.go
+++ b/component/metrics/mse_test.go
@@ -43,7 +43,8 @@ func TestMSE(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if result := metric.Result(); result != 1. {
+			result := metric.Result()
+			if !(1.-1e-12 < result && result < 1.+1e-12) {
 				t.Fatalf("expected result to be (1): got (%f)", result)
 			}
 		})
@@ -91,7 +92,8 @@ func TestMSE(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if result := metric.Result(); result != 11.5 {
+			result := metric.Result()
+			if !(11.5-1e-12 < result && result < 11.5+1e-12) {
 				t.Fatalf("expected result to be (11.5): got (%f)", result)
 			}
 		})
@@ -159,7 +161,8 @@ func TestMSE(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if result := metric.Result(); result != 8.6 {
+			result := metric.Result()
+			if !(8.6-1e-12 < result && result < 8.6+1e-12) {
 				t.Fatalf("expected result to be (8.6): got (%f)", result)
 			}
 		})

--- a/component/metrics/mse_test.go
+++ b/component/metrics/mse_test.go
@@ -43,9 +43,8 @@ func TestMSE(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			result := metric.Result()
-			if !(1.-1e-5 < result && result < 1.+1e-5) {
-				t.Fatalf("expected result to be (1): got (%f)", result)
+			if res := metric.Result(); res != 1. {
+				t.Fatalf("expected result to be (1): got (%f)", res)
 			}
 		})
 
@@ -92,9 +91,8 @@ func TestMSE(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			result := metric.Result()
-			if !(11.5-1e-5 < result && result < 11.5+1e-5) {
-				t.Fatalf("expected result to be (11.5): got (%f)", result)
+			if res := metric.Result(); res != 11.5 {
+				t.Fatalf("expected result to be (11.5): got (%f)", res)
 			}
 		})
 
@@ -161,9 +159,8 @@ func TestMSE(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			result := metric.Result()
-			if !(8.6-1e-5 < result && result < 8.6+1e-5) {
-				t.Fatalf("expected result to be (8.6): got (%f)", result)
+			if res := metric.Result(); res != 8.6 {
+				t.Fatalf("expected result to be (8.6): got (%f)", res)
 			}
 		})
 

--- a/component/metrics/mse_test.go
+++ b/component/metrics/mse_test.go
@@ -44,7 +44,7 @@ func TestMSE(t *testing.T) {
 			}
 
 			result := metric.Result()
-			if !(1.-1e-12 < result && result < 1.+1e-12) {
+			if !(1.-1e-5 < result && result < 1.+1e-5) {
 				t.Fatalf("expected result to be (1): got (%f)", result)
 			}
 		})
@@ -93,7 +93,7 @@ func TestMSE(t *testing.T) {
 			}
 
 			result := metric.Result()
-			if !(11.5-1e-12 < result && result < 11.5+1e-12) {
+			if !(11.5-1e-5 < result && result < 11.5+1e-5) {
 				t.Fatalf("expected result to be (11.5): got (%f)", result)
 			}
 		})
@@ -162,7 +162,7 @@ func TestMSE(t *testing.T) {
 			}
 
 			result := metric.Result()
-			if !(8.6-1e-12 < result && result < 8.6+1e-12) {
+			if !(8.6-1e-5 < result && result < 8.6+1e-5) {
 				t.Fatalf("expected result to be (8.6): got (%f)", result)
 			}
 		})

--- a/component/metrics/mse_test.go
+++ b/component/metrics/mse_test.go
@@ -43,8 +43,7 @@ func TestMSE(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			result := metric.Result()
-			if !(1.-1e-10 < result && result < 1.+1e-10) {
+			if result := metric.Result(); result != 1. {
 				t.Fatalf("expected result to be (1): got (%f)", result)
 			}
 		})
@@ -92,8 +91,7 @@ func TestMSE(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			result := metric.Result()
-			if !(11.5-1e-10 < result && result < 11.5+1e-10) {
+			if result := metric.Result(); result != 11.5 {
 				t.Fatalf("expected result to be (11.5): got (%f)", result)
 			}
 		})
@@ -161,8 +159,7 @@ func TestMSE(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			result := metric.Result()
-			if !(8.6-1e-10 < result && result < 8.6+1e-10) {
+			if result := metric.Result(); result != 8.6 {
 				t.Fatalf("expected result to be (8.6): got (%f)", result)
 			}
 		})

--- a/component/optimizers/adam_test.go
+++ b/component/optimizers/adam_test.go
@@ -272,11 +272,11 @@ func TestAdam(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			expl, err := tensor.Full(nil, 0.999-1e-10, &tensor.Config{Device: dev})
+			expl, err := tensor.Full(nil, 0.999-1e-5, &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}
-			expu, err := tensor.Full(nil, 0.999+1e-10, &tensor.Config{Device: dev})
+			expu, err := tensor.Full(nil, 0.999+1e-5, &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -305,11 +305,11 @@ func TestAdam(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			expl, err = tensor.Full(nil, 0.998-1e-10, &tensor.Config{Device: dev})
+			expl, err = tensor.Full(nil, 0.998-1e-5, &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}
-			expu, err = tensor.Full(nil, 0.998+1e-10, &tensor.Config{Device: dev})
+			expu, err = tensor.Full(nil, 0.998+1e-5, &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -352,11 +352,11 @@ func TestAdam(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			expl, err := tensor.Full(nil, 0.999-1e-10, &tensor.Config{Device: dev})
+			expl, err := tensor.Full(nil, 0.999-1e-5, &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}
-			expu, err := tensor.Full(nil, 0.999+1e-10, &tensor.Config{Device: dev})
+			expu, err := tensor.Full(nil, 0.999+1e-5, &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -385,11 +385,11 @@ func TestAdam(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			expl, err = tensor.Full(nil, 0.998-1e-10, &tensor.Config{Device: dev})
+			expl, err = tensor.Full(nil, 0.998-1e-5, &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}
-			expu, err = tensor.Full(nil, 0.998+1e-10, &tensor.Config{Device: dev})
+			expu, err = tensor.Full(nil, 0.998+1e-5, &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -541,7 +541,7 @@ func TestModel(t *testing.T) {
 			}
 
 			// ----- then -----
-			if val := result["MSE"]; val != 3.75 {
+			if val := result["MSE"]; !(3.74-1e-12 < val && val < 3.76+1e-12) {
 				t.Fatalf("expected metric value to be (3.75): got (%f)", val)
 			}
 		})
@@ -601,7 +601,7 @@ func TestModel(t *testing.T) {
 			}
 
 			// ----- then -----
-			if val := result["MSE"]; val != 0.25 {
+			if val := result["MSE"]; !(0.25-1e-12 < val && val < 0.25+1e-12) {
 				t.Fatalf("expected metric value to be (0.25): got (%f)", val)
 			}
 		})

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -541,7 +541,7 @@ func TestModel(t *testing.T) {
 			}
 
 			// ----- then -----
-			if val := result["MSE"]; !(3.74-1e-10 < val && val < 3.76+1e-10) {
+			if val := result["MSE"]; val != 3.75 {
 				t.Fatalf("expected metric value to be (3.75): got (%f)", val)
 			}
 		})
@@ -601,7 +601,7 @@ func TestModel(t *testing.T) {
 			}
 
 			// ----- then -----
-			if val := result["MSE"]; !(0.25-1e-10 < val && val < 0.25+1e-10) {
+			if val := result["MSE"]; val != 0.25 {
 				t.Fatalf("expected metric value to be (0.25): got (%f)", val)
 			}
 		})

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -541,7 +541,7 @@ func TestModel(t *testing.T) {
 			}
 
 			// ----- then -----
-			if val := result["MSE"]; !(3.74-1e-12 < val && val < 3.76+1e-12) {
+			if val := result["MSE"]; !(3.74-1e-5 < val && val < 3.76+1e-5) {
 				t.Fatalf("expected metric value to be (3.75): got (%f)", val)
 			}
 		})
@@ -601,7 +601,7 @@ func TestModel(t *testing.T) {
 			}
 
 			// ----- then -----
-			if val := result["MSE"]; !(0.25-1e-12 < val && val < 0.25+1e-12) {
+			if val := result["MSE"]; !(0.25-1e-5 < val && val < 0.25+1e-5) {
 				t.Fatalf("expected metric value to be (0.25): got (%f)", val)
 			}
 		})

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -541,7 +541,7 @@ func TestModel(t *testing.T) {
 			}
 
 			// ----- then -----
-			if val := result["MSE"]; !(3.74-1e-5 < val && val < 3.76+1e-5) {
+			if val := result["MSE"]; val != 3.75 {
 				t.Fatalf("expected metric value to be (3.75): got (%f)", val)
 			}
 		})
@@ -601,7 +601,7 @@ func TestModel(t *testing.T) {
 			}
 
 			// ----- then -----
-			if val := result["MSE"]; !(0.25-1e-5 < val && val < 0.25+1e-5) {
+			if val := result["MSE"]; val != 0.25 {
 				t.Fatalf("expected metric value to be (0.25): got (%f)", val)
 			}
 		})

--- a/tensor/internal/cputensor/operators.go
+++ b/tensor/internal/cputensor/operators.go
@@ -6,8 +6,6 @@ import (
 	"github.com/sahandsafizadeh/qeep/tensor/internal/util"
 )
 
-const float64EqualityThreshold = 1e-12
-
 func (t *CPUTensor) scale(u float64) *CPUTensor {
 	return applyUnaryFuncOnTensorElemWise(t, func(a float64) float64 { return u * a })
 }
@@ -51,7 +49,7 @@ func (t *CPUTensor) tanh() *CPUTensor {
 func (t *CPUTensor) eq(u *CPUTensor) *CPUTensor {
 	return applyBinaryFuncOnTensorsElemWise(t, u,
 		func(a, b float64) float64 {
-			if math.Abs(a-b) <= float64EqualityThreshold {
+			if a == b {
 				return 1.
 			} else {
 				return 0.
@@ -62,10 +60,10 @@ func (t *CPUTensor) eq(u *CPUTensor) *CPUTensor {
 func (t *CPUTensor) ne(u *CPUTensor) *CPUTensor {
 	return applyBinaryFuncOnTensorsElemWise(t, u,
 		func(a, b float64) float64 {
-			if math.Abs(a-b) <= float64EqualityThreshold {
-				return 0.
-			} else {
+			if a != b {
 				return 1.
+			} else {
+				return 0.
 			}
 		})
 }
@@ -215,7 +213,14 @@ func (t *CPUTensor) matMul(u *CPUTensor) *CPUTensor {
 }
 
 func (t *CPUTensor) equals(u *CPUTensor) bool {
-	o := t.eq(u)
-	n := o.numElems()
-	return o.sum() >= float64(n)
+	o := applyBinaryFuncOnTensorsElemWise(t, u,
+		func(a, b float64) float64 {
+			if math.Abs(a-b) <= 1e-12 {
+				return 1.
+			} else {
+				return 0.
+			}
+		})
+
+	return o.avg() >= 1
 }

--- a/tensor/internal/cputensor/operators.go
+++ b/tensor/internal/cputensor/operators.go
@@ -6,6 +6,11 @@ import (
 	"github.com/sahandsafizadeh/qeep/tensor/internal/util"
 )
 
+const (
+	float64EqThreshold     = 1e-240
+	float64EqualsThreshold = 1e-12
+)
+
 func (t *CPUTensor) scale(u float64) *CPUTensor {
 	return applyUnaryFuncOnTensorElemWise(t, func(a float64) float64 { return u * a })
 }
@@ -49,7 +54,7 @@ func (t *CPUTensor) tanh() *CPUTensor {
 func (t *CPUTensor) eq(u *CPUTensor) *CPUTensor {
 	return applyBinaryFuncOnTensorsElemWise(t, u,
 		func(a, b float64) float64 {
-			if a == b {
+			if math.Abs(a-b) <= float64EqThreshold {
 				return 1.
 			} else {
 				return 0.
@@ -60,10 +65,10 @@ func (t *CPUTensor) eq(u *CPUTensor) *CPUTensor {
 func (t *CPUTensor) ne(u *CPUTensor) *CPUTensor {
 	return applyBinaryFuncOnTensorsElemWise(t, u,
 		func(a, b float64) float64 {
-			if a != b {
-				return 1.
-			} else {
+			if math.Abs(a-b) <= float64EqThreshold {
 				return 0.
+			} else {
+				return 1.
 			}
 		})
 }
@@ -215,7 +220,7 @@ func (t *CPUTensor) matMul(u *CPUTensor) *CPUTensor {
 func (t *CPUTensor) equals(u *CPUTensor) bool {
 	o := applyBinaryFuncOnTensorsElemWise(t, u,
 		func(a, b float64) float64 {
-			if math.Abs(a-b) <= 1e-12 {
+			if math.Abs(a-b) <= float64EqualsThreshold {
 				return 1.
 			} else {
 				return 0.

--- a/tensor/internal/cputensor/operators.go
+++ b/tensor/internal/cputensor/operators.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	float64EqThreshold     = 1e-240
-	float64EqualsThreshold = 1e-12
+	float64EqThreshold     = 1e-15
+	float64EqualsThreshold = 1e-10
 )
 
 func (t *CPUTensor) scale(u float64) *CPUTensor {

--- a/tensor/internal/cudatensor/cuda_c/cudatensor.h
+++ b/tensor/internal/cudatensor/cuda_c/cudatensor.h
@@ -59,6 +59,7 @@ double *Mul(CUDATensor a, CUDATensor b, CUDAView view_o);
 double *Div(CUDATensor a, CUDATensor b, CUDAView view_o);
 double *Dot(CUDATensor a, CUDATensor b, CUDAView view_o);
 double *MatMul(CUDATensor a, CUDATensor b, CUDAView view_o);
+double *Equals(CUDATensor a, CUDATensor b, CUDAView view_o);
 
 /*--------------- memory -----------------*/
 void GetCudaMemInfo(size_t *free_mem, size_t *total_mem);

--- a/tensor/internal/cudatensor/cuda_c/operators.cu
+++ b/tensor/internal/cudatensor/cuda_c/operators.cu
@@ -31,6 +31,9 @@ enum OperationType
     OP_EQUALS,
 };
 
+const double DOUBLE_EQ_THRESHOLD = 1e-240;
+const double DOUBLE_EQUALS_THRESHOLD = 1e-12;
+
 /* ----- device functions ----- */
 
 __device__ inline double halfBinaryOp(double x, double a, OperationType opt)
@@ -76,9 +79,9 @@ __device__ inline double binaryOp(double a, double b, OperationType opt)
     switch (opt)
     {
     case OP_EQ:
-        return a == b ? 1. : 0.;
+        return fabs(a - b) <= DOUBLE_EQ_THRESHOLD ? 1. : 0.;
     case OP_NE:
-        return a != b ? 1. : 0.;
+        return fabs(a - b) <= DOUBLE_EQ_THRESHOLD ? 0. : 1.;
     case OP_GT:
         return a > b ? 1. : 0.;
     case OP_GE:
@@ -100,7 +103,7 @@ __device__ inline double binaryOp(double a, double b, OperationType opt)
     case OP_DIV:
         return a / b;
     case OP_EQUALS:
-        return fabs(a - b) <= 1e-12 ? 1. : 0.;
+        return fabs(a - b) <= DOUBLE_EQUALS_THRESHOLD ? 1. : 0.;
     }
 
     return NAN;

--- a/tensor/internal/cudatensor/cuda_c/operators.cu
+++ b/tensor/internal/cudatensor/cuda_c/operators.cu
@@ -31,8 +31,8 @@ enum OperationType
     OP_EQUALS,
 };
 
-const double DOUBLE_EQ_THRESHOLD = 1e-240;
-const double DOUBLE_EQUALS_THRESHOLD = 1e-12;
+const double DOUBLE_EQ_THRESHOLD = 1e-15;
+const double DOUBLE_EQUALS_THRESHOLD = 1e-10;
 
 /* ----- device functions ----- */
 

--- a/tensor/internal/cudatensor/cuda_c/operators.cu
+++ b/tensor/internal/cudatensor/cuda_c/operators.cu
@@ -79,8 +79,6 @@ __device__ inline double binaryOp(double a, double b, OperationType opt)
         return a == b ? 1. : 0.;
     case OP_NE:
         return a != b ? 1. : 0.;
-    case OP_EQUALS:
-        return fabs(a - b) <= 1e-12 ? 1. : 0.;
     case OP_GT:
         return a > b ? 1. : 0.;
     case OP_GE:
@@ -101,6 +99,8 @@ __device__ inline double binaryOp(double a, double b, OperationType opt)
         return a * b;
     case OP_DIV:
         return a / b;
+    case OP_EQUALS:
+        return fabs(a - b) <= 1e-12 ? 1. : 0.;
     }
 
     return NAN;

--- a/tensor/internal/cudatensor/cuda_c/operators.cu
+++ b/tensor/internal/cudatensor/cuda_c/operators.cu
@@ -28,9 +28,8 @@ enum OperationType
     OP_SUB,
     OP_MUL,
     OP_DIV,
+    OP_EQUALS,
 };
-
-const double DOUBLE_EQUALITY_THRESHOLD = 1e-12;
 
 /* ----- device functions ----- */
 
@@ -77,9 +76,11 @@ __device__ inline double binaryOp(double a, double b, OperationType opt)
     switch (opt)
     {
     case OP_EQ:
-        return fabs(a - b) <= DOUBLE_EQUALITY_THRESHOLD ? 1. : 0.;
+        return a == b ? 1. : 0.;
     case OP_NE:
-        return fabs(a - b) <= DOUBLE_EQUALITY_THRESHOLD ? 0. : 1.;
+        return a != b ? 1. : 0.;
+    case OP_EQUALS:
+        return fabs(a - b) <= 1e-12 ? 1. : 0.;
     case OP_GT:
         return a > b ? 1. : 0.;
     case OP_GE:
@@ -324,6 +325,7 @@ extern "C"
     double *Div(CUDATensor a, CUDATensor b, CUDAView view_o);
     double *Dot(CUDATensor a, CUDATensor b, CUDAView view_o);
     double *MatMul(CUDATensor a, CUDATensor b, CUDAView view_o);
+    double *Equals(CUDATensor a, CUDATensor b, CUDAView view_o);
 }
 
 double *Scale(CUDATensor x, double a, CUDAView view_o)
@@ -444,4 +446,9 @@ double *Dot(CUDATensor a, CUDATensor b, CUDAView view_o)
 double *MatMul(CUDATensor a, CUDATensor b, CUDAView view_o)
 {
     return runMatMul(a, b, view_o);
+}
+
+double *Equals(CUDATensor a, CUDATensor b, CUDAView view_o)
+{
+    return runBinaryOp(a, b, OP_EQUALS, view_o);
 }

--- a/tensor/internal/cudatensor/operators.go
+++ b/tensor/internal/cudatensor/operators.go
@@ -159,9 +159,11 @@ func (t *CUDATensor) matMul(u *CUDATensor) *CUDATensor {
 }
 
 func (t *CUDATensor) equals(u *CUDATensor) bool {
-	o := t.eq(u)
-	n := o.numElems()
-	return o.sum() >= float64(n)
+	o := applyBinaryOperation(t, u, t.dims, func(a C.CUDATensor, b C.CUDATensor, view_o C.CUDAView) *C.double {
+		return C.Equals(a, b, view_o)
+	})
+
+	return o.avg() >= 1
 }
 
 func applyHalfBinaryOperation(x *CUDATensor, a float64, dims []int, hbf_c halfBinaryOperatorFunc_C) *CUDATensor {

--- a/tensor/tensor_test/forward_test/operators_test.go
+++ b/tensor/tensor_test/forward_test/operators_test.go
@@ -417,10 +417,15 @@ func TestSin(t *testing.T) {
 
 			act := ten.Sin()
 
-			if val, err := act.At(); err != nil {
+			exp, err := tensor.Of(0., &tensor.Config{Device: dev})
+			if err != nil {
 				t.Fatal(err)
-			} else if !(0.-1e-10 < val && val < 0.+1e-10) {
-				t.Fatalf("expected scalar tensor value to be (0): got (%f)", val)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -432,10 +437,15 @@ func TestSin(t *testing.T) {
 
 			act := ten.Sin()
 
-			if val, err := act.At(); err != nil {
+			exp, err := tensor.Of(0.5, &tensor.Config{Device: dev})
+			if err != nil {
 				t.Fatal(err)
-			} else if !(0.5-1e-10 < val && val < 0.5+1e-10) {
-				t.Fatalf("expected scalar tensor value to be (0.5): got (%f)", val)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -447,10 +457,15 @@ func TestSin(t *testing.T) {
 
 			act := ten.Sin()
 
-			if val, err := act.At(); err != nil {
+			exp, err := tensor.Of(1., &tensor.Config{Device: dev})
+			if err != nil {
 				t.Fatal(err)
-			} else if !(1.-1e-10 < val && val < 1.+1e-10) {
-				t.Fatalf("expected scalar tensor value to be (1): got (%f)", val)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -489,10 +504,15 @@ func TestCos(t *testing.T) {
 
 			act := ten.Cos()
 
-			if val, err := act.At(); err != nil {
+			exp, err := tensor.Of(1., &tensor.Config{Device: dev})
+			if err != nil {
 				t.Fatal(err)
-			} else if !(1.-1e-10 < val && val < 1.+1e-10) {
-				t.Fatalf("expected scalar tensor value to be (1): got (%f)", val)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -504,10 +524,15 @@ func TestCos(t *testing.T) {
 
 			act := ten.Cos()
 
-			if val, err := act.At(); err != nil {
+			exp, err := tensor.Of(0.5, &tensor.Config{Device: dev})
+			if err != nil {
 				t.Fatal(err)
-			} else if !(0.5-1e-10 < val && val < 0.5+1e-10) {
-				t.Fatalf("expected scalar tensor value to be (0.5): got (%f)", val)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -519,10 +544,15 @@ func TestCos(t *testing.T) {
 
 			act := ten.Cos()
 
-			if val, err := act.At(); err != nil {
+			exp, err := tensor.Of(0., &tensor.Config{Device: dev})
+			if err != nil {
 				t.Fatal(err)
-			} else if !(0.-1e-10 < val && val < 0.+1e-10) {
-				t.Fatalf("expected scalar tensor value to be (0): got (%f)", val)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -561,10 +591,15 @@ func TestTan(t *testing.T) {
 
 			act := ten.Tan()
 
-			if val, err := act.At(); err != nil {
+			exp, err := tensor.Of(0., &tensor.Config{Device: dev})
+			if err != nil {
 				t.Fatal(err)
-			} else if !(0.-1e-10 < val && val < 0.+1e-10) {
-				t.Fatalf("expected scalar tensor value to be (0): got (%f)", val)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -576,10 +611,15 @@ func TestTan(t *testing.T) {
 
 			act := ten.Tan()
 
-			if val, err := act.At(); err != nil {
+			exp, err := tensor.Of(1., &tensor.Config{Device: dev})
+			if err != nil {
 				t.Fatal(err)
-			} else if !(1.-1e-10 < val && val < 1.+1e-10) {
-				t.Fatalf("expected scalar tensor value to be (1): got (%f)", val)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -618,10 +658,15 @@ func TestSinh(t *testing.T) {
 
 			act := ten.Sinh()
 
-			if val, err := act.At(); err != nil {
+			exp, err := tensor.Of(0., &tensor.Config{Device: dev})
+			if err != nil {
 				t.Fatal(err)
-			} else if !(0.-1e-10 < val && val < 0.+1e-10) {
-				t.Fatalf("expected scalar tensor value to be (0): got (%f)", val)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -632,12 +677,16 @@ func TestSinh(t *testing.T) {
 			}
 
 			act := ten.Sinh()
-			c := (math.E*math.E - 1) / (2 * math.E)
 
-			if val, err := act.At(); err != nil {
+			exp, err := tensor.Of((math.E*math.E-1)/(2*math.E), &tensor.Config{Device: dev})
+			if err != nil {
 				t.Fatal(err)
-			} else if !(c-1e-10 < val && val < c+1e-10) {
-				t.Fatalf("expected scalar tensor value to be (e^2-1)/(2e): got (%f)", val)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -676,10 +725,15 @@ func TestCosh(t *testing.T) {
 
 			act := ten.Cosh()
 
-			if val, err := act.At(); err != nil {
+			exp, err := tensor.Of(1., &tensor.Config{Device: dev})
+			if err != nil {
 				t.Fatal(err)
-			} else if !(1.-1e-10 < val && val < 1.+1e-10) {
-				t.Fatalf("expected scalar tensor value to be (1): got (%f)", val)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -690,12 +744,16 @@ func TestCosh(t *testing.T) {
 			}
 
 			act := ten.Cosh()
-			c := (math.E*math.E + 1) / (2 * math.E)
 
-			if val, err := act.At(); err != nil {
+			exp, err := tensor.Of((math.E*math.E+1)/(2*math.E), &tensor.Config{Device: dev})
+			if err != nil {
 				t.Fatal(err)
-			} else if !(c-1e-10 < val && val < c+1e-10) {
-				t.Fatalf("expected scalar tensor value to be (e^2+1)/(2e): got (%f)", val)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -734,10 +792,15 @@ func TestTanh(t *testing.T) {
 
 			act := ten.Tanh()
 
-			if val, err := act.At(); err != nil {
+			exp, err := tensor.Of(0., &tensor.Config{Device: dev})
+			if err != nil {
 				t.Fatal(err)
-			} else if !(0.-1e-10 < val && val < 0.+1e-10) {
-				t.Fatalf("expected scalar tensor value to be (0): got (%f)", val)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -749,10 +812,15 @@ func TestTanh(t *testing.T) {
 
 			act := ten.Tanh()
 
-			if val, err := act.At(); err != nil {
+			exp, err := tensor.Of(-1., &tensor.Config{Device: dev})
+			if err != nil {
 				t.Fatal(err)
-			} else if !(-1.-1e-10 < val && val < -1.+1e-10) {
-				t.Fatalf("expected scalar tensor value to be (-1): got (%f)", val)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -764,10 +832,15 @@ func TestTanh(t *testing.T) {
 
 			act := ten.Tanh()
 
-			if val, err := act.At(); err != nil {
+			exp, err := tensor.Of(1., &tensor.Config{Device: dev})
+			if err != nil {
 				t.Fatal(err)
-			} else if !(1.-1e-10 < val && val < 1.+1e-10) {
-				t.Fatalf("expected scalar tensor value to be (1): got (%f)", val)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -778,12 +851,16 @@ func TestTanh(t *testing.T) {
 			}
 
 			act := ten.Tanh()
-			c := (math.E*math.E - 1) / (math.E*math.E + 1)
 
-			if val, err := act.At(); err != nil {
+			exp, err := tensor.Of((math.E*math.E-1)/(math.E*math.E+1), &tensor.Config{Device: dev})
+			if err != nil {
 				t.Fatal(err)
-			} else if !(c-1e-10 < val && val < c+1e-10) {
-				t.Fatalf("expected scalar tensor value to be (e^2-1)/(e^2+1): got (%f)", val)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 

--- a/tensor/tensor_test/forward_test/operators_test.go
+++ b/tensor/tensor_test/forward_test/operators_test.go
@@ -919,7 +919,7 @@ func TestEq(t *testing.T) {
 		})
 
 		t.Run("1D tensor [0, e+eps] / Eq([0, e]) / returns [1, 0]", func(t *testing.T) {
-			t1, err := tensor.Of([]float64{0., math.E + 1e-10}, &tensor.Config{Device: dev})
+			t1, err := tensor.Of([]float64{0., math.E + 1e-15}, &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1118,7 +1118,7 @@ func TestNe(t *testing.T) {
 		})
 
 		t.Run("1D tensor [0, e+eps] / Ne([0, e]) / returns [0, 1]", func(t *testing.T) {
-			t1, err := tensor.Of([]float64{0., math.E + 1e-10}, &tensor.Config{Device: dev})
+			t1, err := tensor.Of([]float64{0., math.E + 1e-15}, &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1317,7 +1317,7 @@ func TestGt(t *testing.T) {
 		})
 
 		t.Run("1D tensor [0, e+eps] / Gt([0, e]) / returns [0, 1]", func(t *testing.T) {
-			t1, err := tensor.Of([]float64{0., math.E + 1e-10}, &tensor.Config{Device: dev})
+			t1, err := tensor.Of([]float64{0., math.E + 1e-15}, &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1516,7 +1516,7 @@ func TestGe(t *testing.T) {
 		})
 
 		t.Run("1D tensor [0, e+eps] / Ge([0, e]) / returns [1, 1]", func(t *testing.T) {
-			t1, err := tensor.Of([]float64{0., math.E + 1e-10}, &tensor.Config{Device: dev})
+			t1, err := tensor.Of([]float64{0., math.E + 1e-15}, &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1715,7 +1715,7 @@ func TestLt(t *testing.T) {
 		})
 
 		t.Run("1D tensor [0, e+eps] / Lt([0, e]) / returns [0, 0]", func(t *testing.T) {
-			t1, err := tensor.Of([]float64{0., math.E + 1e-10}, &tensor.Config{Device: dev})
+			t1, err := tensor.Of([]float64{0., math.E + 1e-15}, &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1914,7 +1914,7 @@ func TestLe(t *testing.T) {
 		})
 
 		t.Run("1D tensor [0, e+eps] / Le([0, e]) / returns [1, 0]", func(t *testing.T) {
-			t1, err := tensor.Of([]float64{0., math.E + 1e-10}, &tensor.Config{Device: dev})
+			t1, err := tensor.Of([]float64{0., math.E + 1e-15}, &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2113,7 +2113,7 @@ func TestElMax(t *testing.T) {
 		})
 
 		t.Run("1D tensor [0, e+eps] / ElMax([0, e]) / returns [0, e+eps]", func(t *testing.T) {
-			t1, err := tensor.Of([]float64{0., math.E + 1e-10}, &tensor.Config{Device: dev})
+			t1, err := tensor.Of([]float64{0., math.E + 1e-15}, &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2127,7 +2127,7 @@ func TestElMax(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			exp, err := tensor.Of([]float64{0., math.E + 1e-10}, &tensor.Config{Device: dev})
+			exp, err := tensor.Of([]float64{0., math.E + 1e-15}, &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2312,7 +2312,7 @@ func TestElMin(t *testing.T) {
 		})
 
 		t.Run("1D tensor [0, e+eps] / ElMin([0, e]) / returns [0, e]", func(t *testing.T) {
-			t1, err := tensor.Of([]float64{0., math.E + 1e-10}, &tensor.Config{Device: dev})
+			t1, err := tensor.Of([]float64{0., math.E + 1e-15}, &tensor.Config{Device: dev})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/tensor/tensor_test/forward_test/reducers_test.go
+++ b/tensor/tensor_test/forward_test/reducers_test.go
@@ -18,8 +18,20 @@ func TestSum(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Sum(); !(9.-1e-10 < val && val < 9.+1e-10) {
-				t.Fatalf("expected (9) as the sum value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Sum(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(9., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -29,8 +41,20 @@ func TestSum(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Sum(); !(10.-1e-10 < val && val < 10.+1e-10) {
-				t.Fatalf("expected (10) as the sum value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Sum(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(10., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -44,8 +68,20 @@ func TestSum(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Sum(); !(36.-1e-10 < val && val < 36.+1e-10) {
-				t.Fatalf("expected (36) as the sum value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Sum(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(36., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 	})
@@ -62,8 +98,20 @@ func TestMax(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Max(); !(9.-1e-10 < val && val < 9.+1e-10) {
-				t.Fatalf("expected (9) as the max value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Max(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(9., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -73,8 +121,20 @@ func TestMax(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Max(); !(6.-1e-10 < val && val < 6.+1e-10) {
-				t.Fatalf("expected (6) as the max value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Max(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(6., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -88,8 +148,20 @@ func TestMax(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Max(); !(9.-1e-10 < val && val < 9.+1e-10) {
-				t.Fatalf("expected (9) as the max value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Max(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(9., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 	})
@@ -106,8 +178,20 @@ func TestMin(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Min(); !(9.-1e-10 < val && val < 9.+1e-10) {
-				t.Fatalf("expected (9) as the min value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Min(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(9., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -117,8 +201,20 @@ func TestMin(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Min(); !(4.-1e-10 < val && val < 4.+1e-10) {
-				t.Fatalf("expected (4) as the min value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Min(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(4., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -132,8 +228,20 @@ func TestMin(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Min(); !(-5.-1e-10 < val && val < -5.+1e-10) {
-				t.Fatalf("expected (-5) as the min value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Min(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(-5., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 	})
@@ -150,8 +258,20 @@ func TestAvg(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Avg(); !(9.-1e-10 < val && val < 9.+1e-10) {
-				t.Fatalf("expected (9) as the avg value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Avg(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(9., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -161,8 +281,20 @@ func TestAvg(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Avg(); !(5.-1e-10 < val && val < 5.+1e-10) {
-				t.Fatalf("expected (5) as the avg value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Avg(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(5., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -176,8 +308,20 @@ func TestAvg(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Avg(); !(3.-1e-10 < val && val < 3.+1e-10) {
-				t.Fatalf("expected (3) as the avg value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Avg(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(3., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -190,8 +334,20 @@ func TestAvg(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Avg(); val != 1e308 {
-				t.Fatalf("expected (1e308) as the avg value of tensor, got (%e)", val)
+			act, err := tensor.Of(ten.Avg(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(1e308, &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 	})
@@ -208,8 +364,20 @@ func TestVar(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Var(); !(0.-1e-10 < val && val < 0.+1e-10) {
-				t.Fatalf("expected (0) as the var value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Var(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(0., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -219,8 +387,20 @@ func TestVar(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Var(); !(4.-1e-10 < val && val < 4.+1e-10) {
-				t.Fatalf("expected (4) as the var value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Var(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(4., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -230,8 +410,20 @@ func TestVar(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Var(); !(4.-1e-10 < val && val < 4.+1e-10) {
-				t.Fatalf("expected (4) as the var value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Var(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(4., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -241,8 +433,20 @@ func TestVar(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Var(); !(0.-1e-10 < val && val < 0.+1e-10) {
-				t.Fatalf("expected (0) as the var value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Var(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(0., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -255,8 +459,20 @@ func TestVar(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Var(); !(6.-1e-10 < val && val < 6.+1e-10) {
-				t.Fatalf("expected (6) as the var value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Var(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(6., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -266,8 +482,20 @@ func TestVar(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Var(); !(9.-1e-10 < val && val < 9.+1e-10) {
-				t.Fatalf("expected (9) as the var value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Var(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(9., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -286,8 +514,20 @@ func TestVar(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Var(); !(13.-1e-10 < val && val < 13.+1e-10) {
-				t.Fatalf("expected (13) as the var value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Var(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(13., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -301,8 +541,20 @@ func TestVar(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Var(); !(9.-1e-10 < val && val < 9.+1e-10) {
-				t.Fatalf("expected (9) as the var value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Var(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(9., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 	})
@@ -319,8 +571,20 @@ func TestStd(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Std(); !(0.-1e-10 < val && val < 0.+1e-10) {
-				t.Fatalf("expected (0) as the std value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Std(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(0., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -330,8 +594,20 @@ func TestStd(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Std(); !(2.-1e-10 < val && val < 2.+1e-10) {
-				t.Fatalf("expected (2) as the std value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Std(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(2., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -341,8 +617,20 @@ func TestStd(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Std(); !(2.-1e-10 < val && val < 2.+1e-10) {
-				t.Fatalf("expected (2) as the std value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Std(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(2., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -352,8 +640,20 @@ func TestStd(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Std(); !(0.-1e-10 < val && val < 0.+1e-10) {
-				t.Fatalf("expected (0) as the std value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Std(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(0., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -363,8 +663,20 @@ func TestStd(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Std(); !(3.-1e-10 < val && val < 3.+1e-10) {
-				t.Fatalf("expected (3) as the std value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Std(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(3., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -377,8 +689,20 @@ func TestStd(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Std(); !(math.Sqrt(6)-1e-10 < val && val < math.Sqrt(6)+1e-10) {
-				t.Fatalf("expected (sqrt(6)) as the std value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Std(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(math.Sqrt(6), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -397,8 +721,20 @@ func TestStd(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Std(); !(math.Sqrt(13)-1e-10 < val && val < math.Sqrt(13)+1e-10) {
-				t.Fatalf("expected (sqrt(13)) as the std value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Std(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(math.Sqrt(13), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -412,8 +748,20 @@ func TestStd(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Std(); !(3.-1e-10 < val && val < 3.+1e-10) {
-				t.Fatalf("expected (3) as the std value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Std(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(3., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 	})
@@ -430,8 +778,20 @@ func TestMean(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Mean(); !(9.-1e-10 < val && val < 9.+1e-10) {
-				t.Fatalf("expected (9) as the mean value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Mean(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(9., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -441,8 +801,20 @@ func TestMean(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Mean(); !(5.-1e-10 < val && val < 5.+1e-10) {
-				t.Fatalf("expected (5) as the mean value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Mean(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(5., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -456,8 +828,20 @@ func TestMean(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Mean(); !(3.-1e-10 < val && val < 3.+1e-10) {
-				t.Fatalf("expected (3) as the mean value of tensor, got (%f)", val)
+			act, err := tensor.Of(ten.Mean(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(3., &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 
@@ -470,8 +854,20 @@ func TestMean(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if val := ten.Mean(); val != 1e308 {
-				t.Fatalf("expected (1e308) as the mean value of tensor, got (%e)", val)
+			act, err := tensor.Of(ten.Mean(), &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			exp, err := tensor.Of(1e308, &tensor.Config{Device: dev})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if eq, err := act.Equals(exp); err != nil {
+				t.Fatal(err)
+			} else if !eq {
+				t.Fatal("expected tensors to be equal")
 			}
 		})
 	})


### PR DESCRIPTION
**1. Fix**: Split `Eq` and `Equals` calculation paths.
- Since `Equals` method is only used in testing, it is now calculated with less accuracy of `1e-10` while `Eq` works with `1e-15` accuracy on both devices.
- To achieve this, paths of `Eq` and `Equals` were separated and a new function was added to `cuda_c` library interface.

**2. Refactor**: Interval checking in tests.
- Following the accuracy reduction of `Equals` method, now most of the test assertions is done through this method. Previous `Lt` and `Gt` pattern is now only used in the necessary places.